### PR TITLE
feat: add basic i18n support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "i18next": "^25.3.2",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
         "next-themes": "^0.3.0",
@@ -50,6 +51,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.53.0",
+        "react-i18next": "^15.6.1",
         "react-qr-code": "^2.0.8",
         "react-resizable-panels": "^2.1.3",
         "react-router-dom": "^6.26.2",
@@ -4229,6 +4231,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4255,6 +4266,37 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "25.3.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.2.tgz",
+      "integrity": "sha512-JSnbZDxRVbphc5jiptxr3o2zocy5dEqpVm9qCGdJwRNO+9saUJS0/u4LnM/13C23fUEWxAylPqKU/NpMV/IjqA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6"
+      },
+      "peerDependencies": {
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -5329,6 +5371,32 @@
         "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.1.tgz",
+      "integrity": "sha512-uGrzSsOUUe2sDBG/+FJq2J1MM+Y4368/QW8OLEKSFvnDflHBbZhSd1u3UkW0Z06rMhZmnB/AQrhCpYfE5/5XNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.27.6",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0",
+        "typescript": "^5"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6269,7 +6337,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -6666,6 +6734,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "i18next": "^25.3.2",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",
     "next-themes": "^0.3.0",
@@ -54,6 +55,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.0",
+    "react-i18next": "^15.6.1",
     "react-qr-code": "^2.0.8",
     "react-resizable-panels": "^2.1.3",
     "react-router-dom": "^6.26.2",
@@ -67,6 +69,9 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.2",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
@@ -83,9 +88,6 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
     "vite": "^5.4.1",
-    "vitest": "^3.2.4",
-    "@testing-library/react": "^16.0.0",
-    "@testing-library/user-event": "^14.5.2",
-    "@testing-library/jest-dom": "^6.4.2"
+    "vitest": "^3.2.4"
   }
 }

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -2,24 +2,25 @@ import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import { Header } from './Header';
+import '../i18n';
 
 const authState = { isAuthenticated: false };
 vi.mock('@/context', () => ({ useAuth: () => authState }));
 vi.mock('./ProfileDrawer', () => ({ ProfileDrawer: () => <div>drawer</div> }));
 
 describe('Header component', () => {
-  it('рендерит ссылки входа и регистрации для гостя', () => {
+  it('renders login and register links for guest', () => {
     authState.isAuthenticated = false;
     render(
       <MemoryRouter>
         <Header />
       </MemoryRouter>,
     );
-    expect(screen.getByText('Вход')).toBeInTheDocument();
-    expect(screen.getByText('Регистрация')).toBeInTheDocument();
+    expect(screen.getByText('Login')).toBeInTheDocument();
+    expect(screen.getByText('Register')).toBeInTheDocument();
   });
 
-  it('рендерит профиль для авторизованного пользователя', () => {
+  it('renders profile for authenticated user', () => {
     authState.isAuthenticated = true;
     render(
       <MemoryRouter>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,10 +4,12 @@ import { Bell, Menu, X } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useAuth } from '@/context';
 import { ProfileDrawer } from './ProfileDrawer';
+import { useTranslation } from 'react-i18next';
 
 export const Header = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const { isAuthenticated } = useAuth();
+  const { t } = useTranslation();
 
   return (
     <header className="bg-gray-800 border-b border-gray-700">
@@ -23,9 +25,9 @@ export const Header = () => {
           {/* Desktop Navigation
           <nav className="hidden md:flex items-center space-x-8">
             <a href="#" className="text-gray-300 hover:text-white transition-colors">P2P</a>
-            <a href="#" className="text-gray-300 hover:text-white transition-colors">Торговля</a>
-            <a href="#" className="text-gray-300 hover:text-white transition-colors">Кошелек</a>
-            <a href="#" className="text-gray-300 hover:text-white transition-colors">История</a>
+            <a href="#" className="text-gray-300 hover:text-white transition-colors">{t('header.trade')}</a>
+            <a href="#" className="text-gray-300 hover:text-white transition-colors">{t('header.wallet')}</a>
+            <a href="#" className="text-gray-300 hover:text-white transition-colors">{t('header.history')}</a>
           </nav>
 */}
           {/* User Actions */}
@@ -41,13 +43,13 @@ export const Header = () => {
                   to="/login"
                   className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded-lg transition-colors"
                 >
-                  Вход
+                  {t('header.login')}
                 </Link>
                 <Link
                   to="/register"
                   className="bg-gray-700 hover:bg-gray-600 px-4 py-2 rounded-lg transition-colors"
                 >
-                  Регистрация
+                  {t('header.register')}
                 </Link>
               </>
             )}
@@ -67,9 +69,9 @@ export const Header = () => {
           <div className="md:hidden py-4 border-t border-gray-700">
             <nav className="flex flex-col space-y-2">
               <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">P2P</a>
-              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">Торговля</a>
-              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">Кошелек</a>
-              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">История</a>
+              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">{t('header.trade')}</a>
+              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">{t('header.wallet')}</a>
+              <a href="#" className="text-gray-300 hover:text-white py-2 transition-colors">{t('header.history')}</a>
               {isAuthenticated ? (
                 <ProfileDrawer triggerClassName="text-gray-300 hover:text-white py-2 transition-colors text-left flex" />
               ) : (
@@ -78,13 +80,13 @@ export const Header = () => {
                     to="/login"
                     className="text-gray-300 hover:text-white py-2 transition-colors"
                   >
-                    Вход
+                    {t('header.login')}
                   </Link>
                   <Link
                     to="/register"
                     className="text-gray-300 hover:text-white py-2 transition-colors"
                   >
-                    Регистрация
+                    {t('header.register')}
                   </Link>
                 </>
               )}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,12 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en/translation.json';
+
+i18n.use(initReactI18next).init({
+  resources: { en: { translation: en } },
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,71 @@
+{
+  "header": {
+    "login": "Login",
+    "register": "Register",
+    "trade": "Trade",
+    "wallet": "Wallet",
+    "history": "History"
+  },
+  "login": {
+    "back": "Back",
+    "title": "Sign In",
+    "subtitle": "Sign in to your account to access trading",
+    "username": "Username",
+    "password": "Password",
+    "usernamePlaceholder": "username",
+    "passwordPlaceholder": "Enter password",
+    "submit": "Sign In",
+    "register": "Register",
+    "forgot": "Forgot password?",
+    "toastSuccess": "You have successfully signed in",
+    "toastErrorPrefix": "Login error: {{message}}",
+    "toastErrorGeneric": "Login error"
+  },
+  "register": {
+    "back": "Back",
+    "title": "Register",
+    "subtitle": "Create an account to start trading",
+    "username": "Username",
+    "password": "Password",
+    "confirmPassword": "Confirm password",
+    "passwordPlaceholder": "Minimum 8 characters",
+    "confirmPasswordPlaceholder": "Repeat password",
+    "submit": "Create account",
+    "seedTitle": "Your seed phrase:",
+    "copy": "Copy",
+    "download": "Download",
+    "toLogin": "Go to login",
+    "login": "Login",
+    "forgot": "Forgot password?",
+    "toastShortPassword": "Password is too short. Minimum 8 characters",
+    "toastPasswordsMismatch": "Passwords do not match",
+    "toastSuccess": "Registration successful",
+    "toastErrorPrefix": "Registration error: {{message}}",
+    "toastErrorGeneric": "Registration failed"
+  },
+  "recover": {
+    "back": "Back to login",
+    "title": "Recover access",
+    "subtitle": "Enter requested words from seed",
+    "successTitle": "Access restored",
+    "successSubtitle": "You have successfully authorized",
+    "username": "Username",
+    "enterWords": "Enter words No {{one}}, {{two}}, {{three}}",
+    "newPassword": "New password",
+    "confirmPassword": "Confirm password",
+    "submit": "Recover",
+    "welcome": "Welcome, {{username}}",
+    "register": "Register",
+    "login": "Login",
+    "toastPositionsError": "Failed to get positions",
+    "toastShortPassword": "Password is too short. Minimum 8 characters",
+    "toastPasswordsMismatch": "Passwords do not match",
+    "toastSuccess": "Password updated and access restored",
+    "toastErrorPrefix": "Recover access error: {{message}}",
+    "toastErrorGeneric": "Recover access error"
+  },
+  "notFound": {
+    "oops": "Oops! Page not found",
+    "returnHome": "Return to Home"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import './i18n';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Login from './Login';
+import '../i18n';
 
 const loginMock = vi.fn();
 vi.mock('@/context/AuthContext', () => ({
@@ -9,7 +10,7 @@ vi.mock('@/context/AuthContext', () => ({
 }));
 
 describe('Login page', () => {
-  it('отправляет учетные данные при сабмите', async () => {
+  it('submits credentials', async () => {
     loginMock.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -20,12 +21,12 @@ describe('Login page', () => {
     fireEvent.change(screen.getByPlaceholderText(/username/i), {
       target: { value: 'user' },
     });
-    fireEvent.change(screen.getByPlaceholderText(/Введите пароль/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Enter password/i), {
       target: { value: 'pass' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /войти/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Sign In/i }));
 
-    await screen.findByText(/Забыли пароль\?/i);
+    await screen.findByText(/Forgot password\?/i);
     expect(loginMock).toHaveBeenCalledWith('user', 'pass');
   });
 });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,29 +1,33 @@
-import {useState} from 'react';
-import {Link, useNavigate} from 'react-router-dom';
-import {Eye, EyeOff, ArrowLeft} from 'lucide-react';
-import {toast} from '@/components/ui/sonner';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { Eye, EyeOff, ArrowLeft } from 'lucide-react';
+import { toast } from '@/components/ui/sonner';
 
-import {useAuth} from '@/context/AuthContext';
+import { useAuth } from '@/context/AuthContext';
+import { useTranslation } from 'react-i18next';
 
 const Login = () => {
     const navigate = useNavigate();
-    const {login} = useAuth();
+    const { login } = useAuth();
     const [showPassword, setShowPassword] = useState(false);
     const [formData, setFormData] = useState({
         username: '',
         password: ''
     });
+    const { t } = useTranslation();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
             await login(formData.username, formData.password);
-            toast('Вы успешно вошли в систему');
+            toast(t('login.toastSuccess'));
             navigate('/');
         } catch (err) {
             console.error('Login error:', err);
             toast(
-                err instanceof Error ? `Ошибка входа: ${err.message}` : 'Ошибка входа',
+                err instanceof Error
+                    ? t('login.toastErrorPrefix', { message: err.message })
+                    : t('login.toastErrorGeneric'),
             );
         }
     };
@@ -35,16 +39,16 @@ const Login = () => {
                     <div className="mb-8">
                         <Link to="/" className="inline-flex items-center text-gray-400 hover:text-white mb-4">
                             <ArrowLeft className="w-4 h-4 mr-2"/>
-                            Назад
+                            {t('login.back')}
                         </Link>
-                        <h1 className="text-2xl font-semibold mb-2">Вход в систему</h1>
-                        <p className="text-gray-300">Войдите в свой аккаунт для доступа к торговле</p>
+                        <h1 className="text-2xl font-semibold mb-2">{t('login.title')}</h1>
+                        <p className="text-gray-300">{t('login.subtitle')}</p>
                     </div>
 
                     <form onSubmit={handleSubmit} className="space-y-6">
                         <div>
                             <label className="block text-sm font-medium text-gray-300 mb-2">
-                                Имя пользователя
+                                {t('login.username')}
                             </label>
                             <input
                                 type="text"
@@ -52,13 +56,13 @@ const Login = () => {
                                 value={formData.username}
                                 onChange={(e) => setFormData({...formData, username: e.target.value})}
                                 className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                placeholder="username"
+                                placeholder={t('login.usernamePlaceholder')}
                             />
                         </div>
 
                         <div>
                             <label className="block text-sm font-medium text-gray-300 mb-2">
-                                Пароль
+                                {t('login.password')}
                             </label>
                             <div className="relative">
                                 <input
@@ -67,7 +71,7 @@ const Login = () => {
                                     value={formData.password}
                                     onChange={(e) => setFormData({...formData, password: e.target.value})}
                                     className="w-full px-3 py-2 pr-10 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                    placeholder="Введите пароль"
+                                    placeholder={t('login.passwordPlaceholder')}
                                 />
                                 <button
                                     type="button"
@@ -84,16 +88,16 @@ const Login = () => {
                             type="submit"
                             className="w-full bg-blue-600 text-white py-2  rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
                         >
-                            Войти
+                            {t('login.submit')}
                         </button>
                     </form>
 
                     <div className="mt-10 flex justify-between text-sm text-gray-300">
                         <Link to="/register" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Зарегистрироваться
+                            {t('login.register')}
                         </Link>
                         <Link to="/recover" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Забыли пароль?
+                            {t('login.forgot')}
                         </Link>
                     </div>
 

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,8 +1,10 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { useTranslation } from 'react-i18next';
 
 const NotFound = () => {
   const location = useLocation();
+  const { t } = useTranslation();
 
   useEffect(() => {
     console.error(
@@ -15,9 +17,9 @@ const NotFound = () => {
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-600 mb-4">{t('notFound.oops')}</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
+          {t('notFound.returnHome')}
         </a>
       </div>
     </div>

--- a/src/pages/Recover.test.tsx
+++ b/src/pages/Recover.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import Recover from './Recover';
+import '../i18n';
 
 const recoverMock = vi.fn();
 vi.mock('@/context', () => ({ useAuth: () => ({ recover: recoverMock }) }));
@@ -13,7 +14,7 @@ const recoverChallengeMock = vi.mocked(recoverChallenge);
 recoverChallengeMock.mockResolvedValue({ positions: [1, 2, 3] });
 
 describe('Recover page', () => {
-  it('отправляет слова и новый пароль', async () => {
+  it('submits words and new password', async () => {
     recoverMock.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -35,7 +36,7 @@ describe('Recover page', () => {
     fireEvent.change(passFields[0], { target: { value: 'password1' } });
     fireEvent.change(passFields[1], { target: { value: 'password1' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /Восстановить/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Recover/i }));
 
     await waitFor(() =>
       expect(recoverMock).toHaveBeenCalledWith(

--- a/src/pages/Recover.tsx
+++ b/src/pages/Recover.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Key, Check, Eye, EyeOff } from "lucide-react";
 import { useAuth } from "@/context";
 import { toast } from "@/components/ui/sonner";
 import { recoverChallenge } from "@/api/auth";
+import { useTranslation } from 'react-i18next';
 
 const Recover = () => {
     const [username, setUsername] = useState("");
@@ -15,7 +16,8 @@ const Recover = () => {
     const [confirmPassword, setConfirmPassword] = useState("");
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirm, setShowConfirm] = useState(false);
-    const {recover} = useAuth();
+    const { recover } = useAuth();
+    const { t } = useTranslation();
 
     const handleUsernameBlur = async () => {
         if (!username) return;
@@ -25,18 +27,18 @@ const Recover = () => {
             setWords(["", "", ""]);
             setChallengeLoaded(true);
         } catch (err) {
-            toast("Не удалось получить позиции");
+            toast(t('recover.toastPositionsError'));
         }
     };
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         if (newPassword.length < 8) {
-            toast("Пароль слишком короткий. Минимум 8 символов");
+            toast(t('recover.toastShortPassword'));
             return;
         }
         if (newPassword !== confirmPassword) {
-            toast("Пароли не совпадают");
+            toast(t('recover.toastPasswordsMismatch'));
             return;
         }
         try {
@@ -46,13 +48,13 @@ const Recover = () => {
             }));
             await recover(username, phrases, newPassword, confirmPassword);
             setIsSubmitted(true);
-            toast("Пароль обновлён и доступ восстановлен");
+            toast(t('recover.toastSuccess'));
         } catch (err) {
             console.error("Recover error:", err);
             toast(
                 err instanceof Error
-                    ? `Ошибка восстановления доступа: ${err.message}`
-                    : "Ошибка восстановления доступа",
+                    ? t('recover.toastErrorPrefix', { message: err.message })
+                    : t('recover.toastErrorGeneric'),
             );
         }
     };
@@ -67,7 +69,7 @@ const Recover = () => {
                             className="inline-flex items-center text-gray-400 hover:text-white mb-4"
                         >
                             <ArrowLeft className="w-4 h-4 mr-2"/>
-                            Назад к входу
+                            {t('recover.back')}
                         </Link>
                         {!isSubmitted ? (
                             <>
@@ -75,10 +77,10 @@ const Recover = () => {
                                     <Key className="w-6 h-6 text-blue-500"/>
                                 </div>
                                 <h1 className="text-2xl font-semibold mb-2">
-                                    Восстановление доступа
+                                    {t('recover.title')}
                                 </h1>
                                 <p className="text-gray-300">
-                                    Введите запрошенные слова из seed
+                                    {t('recover.subtitle')}
                                 </p>
                             </>
                         ) : (
@@ -88,9 +90,9 @@ const Recover = () => {
                                     <Check className="w-6 h-6 text-white"/>
                                 </div>
                                 <h1 className="text-2xl font-semibold mb-2">
-                                    Доступ восстановлен
+                                    {t('recover.successTitle')}
                                 </h1>
-                                <p className="text-gray-300">Вы успешно авторизованы</p>
+                                <p className="text-gray-300">{t('recover.successSubtitle')}</p>
                             </>
                         )}
                     </div>
@@ -98,7 +100,7 @@ const Recover = () => {
                         <form onSubmit={handleSubmit} className="space-y-6">
                             <div>
                                 <label className="block text-sm font-medium text-gray-300 mb-2">
-                                    Username
+                                    {t('recover.username')}
                                 </label>
                                 <input
                                     type="text"
@@ -113,7 +115,7 @@ const Recover = () => {
                             {challengeLoaded && (
                                 <div>
                                     <label className="block text-sm font-medium text-gray-300 mb-2">
-                                        Введите слова № {indices[0]}, {indices[1]}, {indices[2]}
+                                        {t('recover.enterWords', { one: indices[0], two: indices[1], three: indices[2] })}
                                     </label>
                                     <div className="grid grid-cols-3 gap-2">
                                         {words.map((w, idx) => (
@@ -139,7 +141,7 @@ const Recover = () => {
                                 <>
                                     <div>
                                         <label className="block text-sm font-medium text-gray-300 mb-2">
-                                            Новый пароль
+                                            {t('recover.newPassword')}
                                         </label>
                                         <div className="relative">
                                             <input
@@ -164,7 +166,7 @@ const Recover = () => {
                                     </div>
                                     <div>
                                         <label className="block text-sm font-medium text-gray-300 mb-2">
-                                            Подтвердите пароль
+                                            {t('recover.confirmPassword')}
                                         </label>
                                         <div className="relative">
                                             <input
@@ -193,14 +195,14 @@ const Recover = () => {
                                 type="submit"
                                 className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
                             >
-                                Восстановить
+                                {t('recover.submit')}
                             </button>
                         </form>
                     ) : (
                         <div className="space-y-4">
                             <div className="p-4 bg-green-700 border border-green-600 rounded-md">
                                 <p className="text-sm text-white">
-                                    Добро пожаловать, {username}
+                                    {t('recover.welcome', { username })}
                                 </p>
                             </div>
                         </div>
@@ -208,10 +210,10 @@ const Recover = () => {
 
                     <div className="mt-10 flex justify-between text-sm text-gray-300">
                         <Link to="/register" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Зарегистрироваться
+                            {t('recover.register')}
                         </Link>
                         <Link to="/login" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Войти
+                            {t('recover.login')}
                         </Link>
                     </div>
 

--- a/src/pages/Register.test.tsx
+++ b/src/pages/Register.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { render, screen, fireEvent } from '@testing-library/react';
 import Register from './Register';
+import '../i18n';
 
 const registerMock = vi.fn();
 vi.mock('@/context', () => ({ useAuth: () => ({ register: registerMock }) }));
@@ -14,7 +15,7 @@ Object.assign(navigator, {
 });
 
 describe('Register page', () => {
-  it('показывает мнемонику после успешной регистрации', async () => {
+  it('shows mnemonic after successful registration', async () => {
     registerMock.mockResolvedValue({ mnemonic: words });
     render(
       <MemoryRouter>
@@ -25,14 +26,14 @@ describe('Register page', () => {
     fireEvent.change(screen.getByPlaceholderText(/Username/i), {
       target: { value: 'user' },
     });
-    fireEvent.change(screen.getByPlaceholderText(/Минимум 8 символов/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Minimum 8 characters/i), {
       target: { value: 'password1' },
     });
-    fireEvent.change(screen.getByPlaceholderText(/Повторите пароль/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Repeat password/i), {
       target: { value: 'password1' },
     });
 
-    fireEvent.click(screen.getByRole('button', { name: /Создать аккаунт/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Create account/i }));
 
     expect(await screen.findByText('1. w1')).toBeInTheDocument();
     expect(registerMock).toHaveBeenCalledWith('user', 'password1', 'password1');

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,29 +1,31 @@
-import {useState} from 'react';
-import {Link} from 'react-router-dom';
-import {Eye, EyeOff, ArrowLeft, Copy, Download} from 'lucide-react';
-import {toast} from '@/components/ui/sonner';
-import {useAuth} from '@/context';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Eye, EyeOff, ArrowLeft, Copy, Download } from 'lucide-react';
+import { toast } from '@/components/ui/sonner';
+import { useAuth } from '@/context';
+import { useTranslation } from 'react-i18next';
 
 const Register = () => {
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-    const {register} = useAuth();
+    const { register } = useAuth();
     const [formData, setFormData] = useState({
         username: '',
         password: '',
         confirmPassword: '',
     });
     const [mnemonic, setMnemonic] = useState<string | null>(null);
+    const { t } = useTranslation();
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
 
         if (formData.password.length < 8) {
-            toast('Пароль слишком короткий. Минимум 8 символов');
+            toast(t('register.toastShortPassword'));
             return;
         }
         if (formData.password !== formData.confirmPassword) {
-            toast('Пароли не совпадают');
+            toast(t('register.toastPasswordsMismatch'));
             return;
         }
 
@@ -40,13 +42,13 @@ const Register = () => {
                         .join(' ')
                     : mnemonic,
             );
-            toast('Успешная регистрация');
+            toast(t('register.toastSuccess'));
         } catch (err) {
             console.error('Registration error:', err);
             toast(
                 err instanceof Error
-                    ? `Ошибка регистрации: ${err.message}`
-                    : 'Не удалось завершить регистрацию',
+                    ? t('register.toastErrorPrefix', { message: err.message })
+                    : t('register.toastErrorGeneric'),
             );
         }
     };
@@ -61,17 +63,18 @@ const Register = () => {
                             className="inline-flex items-center text-gray-400 hover:text-white mb-4"
                         >
                             <ArrowLeft className="w-4 h-4 mr-2"/>
-                            Назад
+                            {t('register.back')}
                         </Link>
-                        <h1 className="text-2xl font-semibold mb-2">Регистрация</h1>
-                        <p className="text-gray-300">Создайте аккаунт для начала торговли</p>
+        
+                        <h1 className="text-2xl font-semibold mb-2">{t('register.title')}</h1>
+                        <p className="text-gray-300">{t('register.subtitle')}</p>
                     </div>
 
                     {!mnemonic ? (
                         <form onSubmit={handleSubmit} className="space-y-6">
                             <div>
                                 <label className="block text-sm font-medium text-gray-300 mb-2">
-                                    Имя пользователя
+                                    {t('register.username')}
                                 </label>
                                 <input
                                     type="text"
@@ -81,13 +84,13 @@ const Register = () => {
                                         setFormData({...formData, username: e.target.value})
                                     }
                                     className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                    placeholder="Username"
+                                    placeholder={t('register.username')}
                                 />
                             </div>
 
                             <div>
                                 <label className="block text-sm font-medium text-gray-300 mb-2">
-                                    Пароль
+                                    {t('register.password')}
                                 </label>
                                 <div className="relative">
                                     <input
@@ -98,7 +101,7 @@ const Register = () => {
                                             setFormData({...formData, password: e.target.value})
                                         }
                                         className="w-full px-3 py-2 pr-10 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="Минимум 8 символов"
+                                        placeholder={t('register.passwordPlaceholder')}
                                     />
                                     <button
                                         type="button"
@@ -112,7 +115,7 @@ const Register = () => {
 
                             <div>
                                 <label className="block text-sm font-medium text-gray-300 mb-2">
-                                    Подтвердите пароль
+                                    {t('register.confirmPassword')}
                                 </label>
                                 <div className="relative">
                                     <input
@@ -123,7 +126,7 @@ const Register = () => {
                                             setFormData({...formData, confirmPassword: e.target.value})
                                         }
                                         className="w-full px-3 py-2 pr-10 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                                        placeholder="Повторите пароль"
+                                        placeholder={t('register.confirmPasswordPlaceholder')}
                                     />
                                     <button
                                         type="button"
@@ -141,14 +144,14 @@ const Register = () => {
                                 type="submit"
                                 className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
                             >
-                                Создать аккаунт
+                                {t('register.submit')}
                             </button>
                             
                         </form>
                     ) : (
                         <div className="space-y-4">
                             <div className="p-4 bg-gray-700 border border-gray-600 rounded-md text-center">
-                                <p className="mb-2 text-sm text-gray-300">Ваша seed-фраза:</p>
+                                <p className="mb-2 text-sm text-gray-300">{t('register.seedTitle')}</p>
                                 <div className="grid grid-cols-2 gap-2 mb-4">
                                     {mnemonic.split(' ').map((word, idx) => (
                                         <div
@@ -165,7 +168,7 @@ const Register = () => {
                                         onClick={() => navigator.clipboard.writeText(mnemonic)}
                                         className="flex items-center text-blue-400 hover:text-blue-300"
                                     >
-                                        <Copy className="w-4 h-4 mr-1"/> Скопировать
+                                        <Copy className="w-4 h-4 mr-1"/> {t('register.copy')}
                                     </button>
                                     <button
                                         type="button"
@@ -180,13 +183,13 @@ const Register = () => {
                                         }}
                                         className="flex items-center text-blue-400 hover:text-blue-300"
                                     >
-                                        <Download className="w-4 h-4 mr-1"/> Скачать
+                                        <Download className="w-4 h-4 mr-1"/> {t('register.download')}
                                     </button>
                                 </div>
                             </div>
                             <div className="text-center">
                                 <Link to="/login" className="text-blue-400 hover:text-blue-300 font-medium">
-                                    Перейти к входу
+                                    {t('register.toLogin')}
                                 </Link>
                             </div>
                         </div>
@@ -195,10 +198,10 @@ const Register = () => {
 
                     <div className="mt-10 flex justify-between text-sm text-gray-300">
                         <Link to="/login" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Войти
+                            {t('register.login')}
                         </Link>
                         <Link to="/recover" className="text-blue-400 hover:text-blue-300 font-medium">
-                            Забыли пароль?
+                            {t('register.forgot')}
                         </Link>
                     </div>
 


### PR DESCRIPTION
## Summary
- add i18next setup with English locale
- update header and auth pages to use translation keys
- translate tests and enable English UI by default

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68976245414c83328b5ec806c229d6a1