### PR TITLE
Добавлен ввод 2FA кода при авторизации

### DIFF
--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -45,10 +45,10 @@ describe("auth api", () => {
         json: async () => ({ access_token: "a", refresh_token: "r" }),
       } as any);
 
-    const tokens = await login("user", "pass");
+    const tokens = await login("user", "pass", "321");
     expect(mockFetch).toHaveBeenCalled();
     const body = JSON.parse(mockFetch.mock.calls[0][1].body);
-    expect(body).toEqual({ username: "user", password: "pass" });
+    expect(body).toEqual({ username: "user", password: "pass", code: "321" });
     expect(tokens).toEqual({ access: "a", refresh: "r" });
   });
 

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -24,10 +24,11 @@ export interface MnemonicResponse {
 export async function login(
   username: string,
   password: string,
+  code?: string,
 ) {
   const { access_token, refresh_token } = await apiRequest<TokenResponse>("/auth/login", {
     method: "POST",
-    body: JSON.stringify({ username, password }),
+    body: JSON.stringify({ username, password, code }),
   });
   return { access: access_token, refresh: refresh_token };
 }

--- a/src/context/AuthContext.test.tsx
+++ b/src/context/AuthContext.test.tsx
@@ -54,7 +54,7 @@ describe("AuthContext", () => {
       await ctx!.login("user", "pass");
     });
 
-    expect(login).toHaveBeenCalledWith("user", "pass");
+    expect(login).toHaveBeenCalledWith("user", "pass", undefined);
     expect(profile).toHaveBeenCalled();
     expect(ctx!.userInfo).toEqual({
       username: "user",

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -30,7 +30,7 @@ interface AuthContextValue {
   tokens: Tokens | null;
   isAuthenticated: boolean;
   userInfo: UserInfo | null;
-  login: (username: string, password: string) => Promise<void>;
+  login: (username: string, password: string, code?: string) => Promise<void>;
   register: (
     username: string,
     password: string,
@@ -78,8 +78,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
   const login = async (
     username: string,
     password: string,
+    code?: string,
   ): Promise<void> => {
-    const t = await apiLogin(username, password);
+    const t = await apiLogin(username, password, code);
     saveTokens(t);
     setTokens(t);
     const p = await apiProfile();

--- a/src/pages/Login.test.tsx
+++ b/src/pages/Login.test.tsx
@@ -26,6 +26,6 @@ describe('Login page', () => {
     fireEvent.click(screen.getByRole('button', { name: /войти/i }));
 
     await screen.findByText(/Забыли пароль\?/i);
-    expect(loginMock).toHaveBeenCalledWith('user', 'pass');
+    expect(loginMock).toHaveBeenCalledWith('user', 'pass', '');
   });
 });

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,13 +11,14 @@ const Login = () => {
     const [showPassword, setShowPassword] = useState(false);
     const [formData, setFormData] = useState({
         username: '',
-        password: ''
+        password: '',
+        code: ''
     });
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
         try {
-            await login(formData.username, formData.password);
+            await login(formData.username, formData.password, formData.code);
             toast('Вы успешно вошли в систему');
             navigate('/');
         } catch (err) {
@@ -79,6 +80,19 @@ const Login = () => {
                             </div>
                         </div>
 
+
+                        <div>
+                            <label className="block text-sm font-medium text-gray-300 mb-2">
+                                Код 2FA
+                            </label>
+                            <input
+                                type="text"
+                                value={formData.code}
+                                onChange={(e) => setFormData({...formData, code: e.target.value})}
+                                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-md text-white focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                                placeholder="123456"
+                            />
+                        </div>
 
                         <button
                             type="submit"


### PR DESCRIPTION
## Summary
- добавлен необязательный параметр `code` в API входа и контекст авторизации
- на странице входа появился ввод 2FA кода
- обновлены тесты под новый формат логина

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_6897643015488332822cf3501d814727