### PR TITLE
fix: pass recovery password to verification API

### DIFF
--- a/src/components/ProfileDrawer.tsx
+++ b/src/components/ProfileDrawer.tsx
@@ -161,8 +161,6 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
     }
   };
 
-  const verifyPassword = async () => verifyPasswordWith(passwordCheck);
-
   const startTwoFactor = async () => {
     try {
       const res = await enable2fa(passwordCheck);
@@ -194,7 +192,7 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
   };
 
   const handleRegenerateWithVerify = async () => {
-    const ok = await verifyPassword();
+    const ok = await verifyPasswordWith(regeneratePassword);
     if (ok) {
       await handleRegenerate();
     }


### PR DESCRIPTION
## Summary
- use actual regeneratePassword when verifying before generating recovery words

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68976354fa3c833296081bf95ef8e474