### PR TITLE
feat: обновить восстановление seed фразы

### DIFF
--- a/src/api/auth.test.ts
+++ b/src/api/auth.test.ts
@@ -9,6 +9,7 @@ import {
   recoverChallenge,
   changePassword,
   verifyPassword,
+  regenerateWords,
   logout,
 } from "./auth";
 
@@ -159,6 +160,25 @@ describe("auth api", () => {
     const body = JSON.parse(opts.body);
     expect(body).toEqual({ password: "pwd" });
     expect(res).toEqual({ verified: true });
+  });
+
+  it("regenerateWords отправляет пароль и возвращает мнемонику", async () => {
+    const mockFetch = vi
+      .spyOn(global, "fetch" as any)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          mnemonic: [{ position: 1, word: "one" }],
+        }),
+      } as any);
+
+    const res = await regenerateWords("pwd");
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect((url as string).endsWith("/auth/mnemonic/regenerate")).toBe(true);
+    const body = JSON.parse(opts.body);
+    expect(body).toEqual({ password: "pwd" });
+    expect(res).toEqual({ mnemonic: [{ position: 1, word: "one" }] });
   });
 
   it("logout делает POST без тела", async () => {

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -18,7 +18,7 @@ export interface RegisterResponse {
 }
 
 export interface MnemonicResponse {
-  mnemonic: string;
+  mnemonic: MnemonicWord[];
 }
 
 export async function login(
@@ -83,7 +83,7 @@ export async function recover(
 }
 
 export async function regenerateWords(password: string) {
-  return apiRequest<MnemonicResponse>("/auth/regenerate", {
+  return apiRequest<MnemonicResponse>("/auth/mnemonic/regenerate", {
     method: "POST",
     body: JSON.stringify({ password }),
   });

--- a/src/components/ProfileDrawer.tsx
+++ b/src/components/ProfileDrawer.tsx
@@ -186,7 +186,11 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
   const handleRegenerate = async () => {
     try {
       const res = await regenerateWords(regeneratePassword);
-      setNewSeed(res.seed);
+      const phrase = res.mnemonic
+        .sort((a, b) => a.position - b.position)
+        .map((w) => w.word)
+        .join(" ");
+      setNewSeed(phrase);
       setRegeneratePassword("");
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
## Summary
- использовать новый эндпоинт `/auth/mnemonic/regenerate` для получения сид-фразы
- переработан диалог Recovery words в профиле
- добавлен тест для API регенерации мнемоники

## Testing
- `npm test`
- `npm run lint` *(есть предупреждения и ошибки ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68976f438df08332b414d51366b402a4