### PR TITLE
Центрирование заголовка и секрета 2FA

### DIFF
--- a/src/components/ProfileDrawer.tsx
+++ b/src/components/ProfileDrawer.tsx
@@ -412,7 +412,7 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
             </DialogTrigger>
             <DialogContent className={modalContentCls}>
             <DialogHeader>
-              <DialogTitle>{t("profile.twoFactorAuth")}</DialogTitle>
+              <DialogTitle className="text-center">{t("profile.twoFactorAuth")}</DialogTitle>
             </DialogHeader>
               {!twoFactorEnabled && !twoFactorSecret && (
                 <div className="space-y-4 mt-4">
@@ -455,8 +455,10 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
                       <QRCode value={otpAuthUrl} size={250} />
                     </div>
                   )}
-                  <p className="text-sm">
-                    {t("profile.secret")}{" "}
+                  <p
+                    className="text-sm text-center cursor-pointer"
+                    onClick={() => navigator.clipboard.writeText(twoFactorSecret)}
+                  >
                     <span className="font-mono break-all">
                       {twoFactorSecret}
                     </span>

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -90,7 +90,6 @@
     "twoFactorAuth": "Two-factor authentication",
     "enable2fa": "Enable 2FA",
     "disable2fa": "Disable 2FA",
-    "secret": "Secret:",
     "recoveryWords": "Recovery words",
     "generate": "Generate",
     "copy": "Copy",


### PR DESCRIPTION
## Summary
- Центрировали заголовок модального окна двухфакторной аутентификации
- Убрали подпись Secret и сделали код по центру с копированием по клику
- Удалили ненужный перевод для подписи Secret

## Testing
- `npm test`
- `npm run lint` *(возвращает ошибки, см. лог)*

------
https://chatgpt.com/codex/tasks/task_e_689773bca0f08332af8c4c83a9988db3