### PR TITLE
feat: load offers on filter change

### DIFF
--- a/src/api/offers.ts
+++ b/src/api/offers.ts
@@ -14,6 +14,33 @@ export interface CreateOfferPayload {
 
 export interface Offer {
   id: string;
+  amount: number;
+  price: number;
+  minAmount: number;
+  maxAmount: number;
+  fromAssetID: string;
+  toAssetID: string;
+  clientID: string;
+}
+
+export interface OfferFilters {
+  from_asset?: string;
+  to_asset?: string;
+  min_amount?: string;
+  max_amount?: string;
+  payment_method?: string;
+  type?: 'buy' | 'sell';
+}
+
+export function getOffers(filters: OfferFilters = {}) {
+  const params = new URLSearchParams();
+  Object.entries(filters).forEach(([key, value]) => {
+    if (value && value !== 'all') {
+      params.set(key, value);
+    }
+  });
+  const query = params.toString();
+  return apiRequest<Offer[]>(`/offers${query ? `?${query}` : ''}`);
 }
 
 export function createOffer(data: CreateOfferPayload) {

--- a/src/components/OrderList.test.tsx
+++ b/src/components/OrderList.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import '../i18n';
+import { OrderList } from './OrderList';
+import { getOffers } from '@/api/offers';
+
+vi.mock('@/api/offers', () => ({
+  getOffers: vi.fn().mockResolvedValue([]),
+}));
+
+describe('OrderList', () => {
+  const baseFilters = {
+    fromAsset: 'all',
+    toAsset: 'all',
+    minAmount: '',
+    maxAmount: '',
+    paymentMethod: 'all',
+  };
+
+  it('запрашивает офферы при монтировании', async () => {
+    render(<OrderList type="buy" filters={baseFilters} />);
+    await waitFor(() => {
+      expect(getOffers).toHaveBeenCalled();
+    });
+  });
+
+  it('запрашивает офферы при изменении фильтров', async () => {
+    const { rerender } = render(
+      <OrderList type="buy" filters={baseFilters} />,
+    );
+    await waitFor(() => expect(getOffers).toHaveBeenCalled());
+    (getOffers as unknown as ReturnType<typeof vi.fn>).mockClear();
+    const newFilters = { ...baseFilters, minAmount: '10' };
+    rerender(<OrderList type="buy" filters={newFilters} />);
+    await waitFor(() => expect(getOffers).toHaveBeenCalled());
+  });
+});

--- a/src/components/OrderList.tsx
+++ b/src/components/OrderList.tsx
@@ -1,4 +1,6 @@
 
+import { useEffect, useState } from 'react';
+import { getOffers } from '@/api/offers';
 import { OrderCard } from './OrderCard';
 
 interface OrderListProps {
@@ -12,55 +14,63 @@ interface OrderListProps {
   };
 }
 
+interface OrderItem {
+  id: string;
+  trader: {
+    name: string;
+    rating: number;
+    completedTrades: number;
+    online: boolean;
+  };
+  currency: string;
+  amount: string;
+  price: string;
+  paymentMethods: string[];
+  limits: { min: string; max: string };
+  type: 'buy' | 'sell';
+}
+
 export const OrderList = ({ type, filters }: OrderListProps) => {
-  // Mock data for demonstration
-  const mockOrders = [
-    {
-      id: '1',
-      trader: {
-        name: 'CryptoTrader98',
-        rating: 4.9,
-        completedTrades: 1247,
-        online: true
-      },
-      currency: 'BTC',
-      amount: '0.5',
-      price: '2,845,000',
-      paymentMethods: ['Сбербанк', 'Тинькофф'],
-      limits: { min: '50,000', max: '500,000' },
-      type: type
-    },
-    {
-      id: '2',
-      trader: {
-        name: 'BitMaster',
-        rating: 4.8,
-        completedTrades: 892,
-        online: true
-      },
-      currency: 'ETH',
-      amount: '2.5',
-      price: '185,000',
-      paymentMethods: ['Альфа-Банк', 'QIWI'],
-      limits: { min: '20,000', max: '300,000' },
-      type: type
-    },
-    {
-      id: '3',
-      trader: {
-        name: 'CoinExpert',
-        rating: 4.95,
-        completedTrades: 2156,
-        online: false
-      },
-      currency: 'USDT',
-      amount: '10,000',
-      price: '95.5',
-      paymentMethods: ['ЮMoney', 'Сбербанк'],
-      limits: { min: '5,000', max: '100,000' },
-      type: type
-    }
-  ];
+  const [orders, setOrders] = useState<OrderItem[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const offers = await getOffers({
+          from_asset: filters.fromAsset,
+          to_asset: filters.toAsset,
+          min_amount: filters.minAmount,
+          max_amount: filters.maxAmount,
+          payment_method: filters.paymentMethod,
+          type,
+        });
+        if (cancelled) return;
+        const mapped = offers.map((o) => ({
+          id: o.id,
+          trader: {
+            name: o.clientID ?? 'Трейдер',
+            rating: 0,
+            completedTrades: 0,
+            online: true,
+          },
+          currency: o.fromAssetID,
+          amount: String(o.amount),
+          price: String(o.price),
+          paymentMethods: [] as string[],
+          limits: { min: String(o.minAmount), max: String(o.maxAmount) },
+          type,
+        }));
+        setOrders(mapped);
+      } catch (err) {
+        console.error('load offers error:', err);
+        if (!cancelled) setOrders([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [type, filters]);
 
   return (
     <div className="space-y-4">
@@ -69,11 +79,11 @@ export const OrderList = ({ type, filters }: OrderListProps) => {
           {type === 'buy' ? 'Объявления о покупке' : 'Объявления о продаже'}
         </h3>
         <span className="text-sm text-gray-400">
-          Найдено: {mockOrders.length} объявлений
+          Найдено: {orders.length} объявлений
         </span>
       </div>
-      
-      {mockOrders.map((order) => (
+
+      {orders.map((order) => (
         <OrderCard key={order.id} order={order} />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- add API helper to fetch offers
- load offers from server when filters change
- cover order list fetching with tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68978711f48c83329a76f88d87c9b9db