### PR TITLE
feat: add balance page with wallet creation

### DIFF
--- a/src/api/balances.test.ts
+++ b/src/api/balances.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { getBalances } from './balances';
+import { createWallet } from './wallets';
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe('balances api', () => {
+  it('getBalances возвращает список балансов', async () => {
+    const mockData = [
+      {
+        amount: 1,
+        id: 'btc',
+        isActive: true,
+        isConvertible: true,
+        name: 'Bitcoin',
+        type: 'crypto',
+        value: 'addr',
+      },
+    ];
+    const mockFetch = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockData,
+      } as any);
+
+    const res = await getBalances();
+    expect(mockFetch).toHaveBeenCalled();
+    expect(res).toEqual(mockData);
+  });
+
+  it('createWallet отправляет asset_id и возвращает кошелек', async () => {
+    const mockWallet = { id: '1', assetID: 'btc', value: 'addr' };
+    const mockFetch = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => mockWallet,
+      } as any);
+
+    const res = await createWallet('btc');
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect((url as string).endsWith('/client/wallets')).toBe(true);
+    expect(opts.method).toBe('POST');
+    expect(JSON.parse(opts.body)).toEqual({ asset_id: 'btc' });
+    expect(res).toEqual(mockWallet);
+  });
+});

--- a/src/api/balances.ts
+++ b/src/api/balances.ts
@@ -1,0 +1,15 @@
+import { apiRequest } from './client';
+
+export interface Balance {
+  amount: number;
+  id: string;
+  isActive: boolean;
+  isConvertible: boolean;
+  name: string;
+  type: string;
+  value?: string;
+}
+
+export async function getBalances() {
+  return apiRequest<Balance[]>('/client/balances');
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,3 +6,5 @@ export * from './dictionaries';
 export * from './pin';
 export * from './offers';
 export * from './clientPaymentMethods';
+export * from './balances';
+export * from './wallets';

--- a/src/api/wallets.ts
+++ b/src/api/wallets.ts
@@ -1,0 +1,14 @@
+import { apiRequest } from './client';
+
+export interface Wallet {
+  id: string;
+  assetID: string;
+  value: string;
+}
+
+export async function createWallet(assetId: string) {
+  return apiRequest<Wallet>('/client/wallets', {
+    method: 'POST',
+    body: JSON.stringify({ asset_id: assetId }),
+  });
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -11,6 +11,10 @@
     "transactions": "Transactions",
     "escrow": "Escrow"
   },
+  "balance": {
+    "getAddress": "Get address",
+    "loading": "Loading..."
+  },
   "login": {
     "back": "Back",
     "title": "Sign In",

--- a/src/pages/Balance.tsx
+++ b/src/pages/Balance.tsx
@@ -1,13 +1,59 @@
+import { useEffect, useState } from 'react';
 import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
+import { getBalances, createWallet, Balance as BalanceType } from '@/api';
 
 const Balance = () => {
   const { t } = useTranslation();
+  const [balances, setBalances] = useState<BalanceType[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getBalances()
+      .then(setBalances)
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleCreateWallet = async (assetId: string) => {
+    const wallet = await createWallet(assetId);
+    setBalances(prev =>
+      prev.map(b => (b.id === assetId ? { ...b, value: wallet.value } : b)),
+    );
+  };
+
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.balance')}</h1>
+        {loading ? (
+          <p>{t('balance.loading')}</p>
+        ) : (
+          <div className="space-y-4">
+            {balances.map((b) => (
+              <div
+                key={b.id}
+                className="p-4 bg-gray-800 rounded-lg flex justify-between items-center"
+              >
+                <div>
+                  <div className="font-semibold">{b.name}</div>
+                  <div className="text-sm text-gray-400">{b.amount}</div>
+                  {b.value && (
+                    <div className="text-sm break-all mt-1">{b.value}</div>
+                  )}
+                </div>
+                {!b.value && (
+                  <button
+                    onClick={() => handleCreateWallet(b.id)}
+                    className="px-4 py-2 bg-blue-600 hover:bg-blue-500 rounded"
+                  >
+                    {t('balance.getAddress')}
+                  </button>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- fetch client balances and allow wallet creation
- expose balances and wallets API helpers
- add translations and tests for balances API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897988c4754833298a0e55cb4860193