### PR TITLE
feat: list client offers on adverts page

### DIFF
--- a/src/api/offers.ts
+++ b/src/api/offers.ts
@@ -21,6 +21,8 @@ export interface Offer {
   fromAssetID: string;
   toAssetID: string;
   clientID: string;
+  createdAt: string;
+  isEnabled?: boolean;
 }
 
 export interface OfferFilters {
@@ -48,4 +50,8 @@ export function createOffer(data: CreateOfferPayload) {
     method: "POST",
     body: JSON.stringify(data),
   });
+}
+
+export function getClientOffers() {
+  return apiRequest<Offer[]>("/client/offers");
 }

--- a/src/pages/Adverts.test.tsx
+++ b/src/pages/Adverts.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import Adverts from './Adverts';
+import '../i18n';
+import { getClientOffers } from '@/api/offers';
+
+vi.mock('@/api/offers', () => ({
+  getClientOffers: vi.fn().mockResolvedValue([
+    {
+      id: '2',
+      amount: 1,
+      price: 2,
+      minAmount: 1,
+      maxAmount: 2,
+      fromAssetID: 'EUR',
+      toAssetID: 'RUB',
+      clientID: 'c1',
+      createdAt: '2024-01-03T00:00:00Z',
+    },
+    {
+      id: '1',
+      amount: 1,
+      price: 2,
+      minAmount: 1,
+      maxAmount: 2,
+      fromAssetID: 'USD',
+      toAssetID: 'RUB',
+      clientID: 'c1',
+      createdAt: '2024-01-02T00:00:00Z',
+    },
+  ]),
+}));
+
+vi.mock('@/context', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+}));
+
+describe('Adverts page', () => {
+  it('отображает офферы клиента в порядке даты создания', async () => {
+    render(
+      <MemoryRouter>
+        <Adverts />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(getClientOffers).toHaveBeenCalled());
+    const items = await screen.findAllByTestId('client-offer');
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent('EUR');
+    expect(items[1]).toHaveTextContent('USD');
+  });
+});

--- a/src/pages/Adverts.tsx
+++ b/src/pages/Adverts.tsx
@@ -1,13 +1,52 @@
+import { useEffect, useState } from 'react';
 import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
+import { getClientOffers, Offer } from '@/api/offers';
 
 const Adverts = () => {
   const { t } = useTranslation();
+  const [offers, setOffers] = useState<Offer[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await getClientOffers();
+        if (cancelled) return;
+        const sorted = [...data].sort(
+          (a, b) =>
+            new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+        );
+        setOffers(sorted);
+      } catch (err) {
+        console.error('load client offers error:', err);
+        if (!cancelled) setOffers([]);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div className="min-h-screen bg-gray-900 text-white">
       <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.adverts')}</h1>
+        <ul className="space-y-4">
+          {offers.map((offer) => (
+            <li key={offer.id} data-testid="client-offer">
+              <div className="bg-gray-700 rounded p-4">
+                <div className="text-sm text-gray-400">
+                  {offer.fromAssetID} → {offer.toAssetID}
+                </div>
+                <div className="font-semibold">
+                  {offer.amount} @ {offer.price}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- show client's own offers on Adverts page sorted by creation date
- add API helper to fetch client offers
- cover Adverts page with tests

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any and other errors)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_6898876b7950833299594d385fdf34e1