### PR TITLE
Убираем блокировку кликов хедера тостом

### DIFF
--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -10,11 +10,11 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       position="top-center"
-      className="toaster group"
+      className="toaster pointer-events-none group"
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "pointer-events-auto group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
## Summary
- не блокируем клики по навигации при показе уведомлений

## Testing
- `npm test`
- `npm run lint` *(fail: Unexpected any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cab590d48332b4a65858abc7f08d