### PR TITLE
feat: add my deals page with order list

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -18,6 +18,32 @@ export interface Order {
   isEscrow?: boolean;
 }
 
+export interface OrderFull {
+  id: string;
+  amount: number;
+  price: number;
+  authorID: string;
+  buyerID: string;
+  sellerID: string;
+  offerOwnerID: string;
+  offerOwner?: {
+    username?: string;
+    rating?: number;
+    ordersCount?: number;
+  };
+  fromAssetID: string;
+  toAssetID: string;
+  fromAsset?: { name?: string };
+  toAsset?: { name?: string };
+  clientPaymentMethodID: string;
+  clientPaymentMethod?: {
+    name?: string;
+    paymentMethod?: { name?: string };
+  };
+  status: string;
+  createdAt: string;
+}
+
 export interface CreateOrderPayload {
   amount: string;
   client_payment_method_id: string;
@@ -30,4 +56,8 @@ export function createOrder(data: CreateOrderPayload) {
     method: 'POST',
     body: JSON.stringify(data),
   });
+}
+
+export function getClientOrders(role: 'author' | 'offerOwner' = 'author') {
+  return apiRequest<OrderFull[]>(`/client/orders?role=${role}`);
 }

--- a/src/components/OrderCard.tsx
+++ b/src/components/OrderCard.tsx
@@ -1,0 +1,91 @@
+import { Star } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import type { OrderFull } from '@/api/orders';
+
+interface OrderCardProps {
+  order: OrderFull;
+}
+
+export const OrderCard = ({ order }: OrderCardProps) => {
+  const { t } = useTranslation();
+  const {
+    id,
+    offerOwner,
+    fromAsset,
+    toAsset,
+    fromAssetID,
+    toAssetID,
+    amount,
+    price,
+    clientPaymentMethod,
+    status,
+    createdAt,
+  } = order;
+
+  const currency = `${fromAsset?.name ?? fromAssetID}/${toAsset?.name ?? toAssetID}`;
+  const paymentMethod =
+    clientPaymentMethod?.paymentMethod?.name ??
+    clientPaymentMethod?.name ??
+    '';
+
+  return (
+    <div className="rounded-2xl border border-white/10 bg-gray-900/60 p-0  transition hover:border-white/20 hover:bg-gray-900/70 text-white shadow-lg">
+      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between p-5 gap-6">
+        <div className="flex items-center gap-4">
+          <div className="relative">
+            <div className="w-12 h-12 rounded-full bg-gradient-to-r from-blue-600 to-blue-700 flex items-center justify-center font-bold">
+              {offerOwner?.username?.charAt(0) ?? '?'}
+            </div>
+          </div>
+          <div>
+            <h4 className="font-semibold text-white tracking-tight">{offerOwner?.username ?? ''}</h4>
+            <div className="flex items-center gap-2 text-sm text-white/60">
+              <div className="flex items-center gap-1">
+                <Star className="w-4 h-4 text-yellow-400 fill-current" />
+                <span>{offerOwner?.rating ?? 0}</span>
+              </div>
+              <span>•</span>
+              <span>{offerOwner?.ordersCount ?? 0} {t('offerCard.trades')}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex-1 lg:mx-8">
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <div>
+              <p className="text-xs text-white/60">{t('offerCard.currency')}</p>
+              <p className="font-medium">{currency}</p>
+            </div>
+            <div>
+              <p className="text-xs text-white/60">{t('offerCard.amount')}</p>
+              <p className="font-medium">{amount}</p>
+            </div>
+            <div>
+              <p className="text-xs text-white/60">{t('offerCard.price')}</p>
+              <p className="font-medium">{price}</p>
+            </div>
+            <div>
+              <p className="text-xs text-white/60">{t('offerCard.paymentMethods')}</p>
+              <p className="font-medium">{paymentMethod}</p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid grid-cols-2 lg:grid-cols-4 gap-4">
+            <div>
+              <p className="text-xs text-white/60">{t('orderCard.status')}</p>
+              <p className="font-medium">{t(`orderStatus.${status}`)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-white/60">{t('orderCard.created')}</p>
+              <p className="font-medium">{new Date(createdAt).toLocaleString()}</p>
+            </div>
+            <div>
+              <p className="text-xs text-white/60">{t('offerCard.id')}</p>
+              <p className="font-medium break-all">{id}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -145,6 +145,18 @@
     "buy": "Buy",
     "sec": "sec"
   },
+  "orderCard": {
+    "status": "Status",
+    "created": "Created",
+    "counterparty": "Counterparty"
+  },
+  "orderStatus": {
+    "OrderStatusWaitPayment": "Waiting payment",
+    "OrderStatusPaid": "Paid",
+    "OrderStatusReleased": "Released",
+    "OrderStatusCancelled": "Cancelled",
+    "OrderStatusDispute": "Dispute"
+  },
   "common": {
     "copy": "Copy",
     "copied": "Copied"

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,13 +1,43 @@
+import { useEffect, useState } from 'react';
 import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
+import { getClientOrders, type OrderFull } from '@/api/orders';
+import { OrderCard } from '@/components/OrderCard';
 
 const Orders = () => {
   const { t } = useTranslation();
+  const [orders, setOrders] = useState<OrderFull[]>([]);
+
+  const loadOrders = async () => {
+    try {
+      const data = await getClientOrders('author');
+      const sorted = [...data].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      setOrders(sorted);
+    } catch (err) {
+      console.error('load client orders error:', err);
+      setOrders([]);
+    }
+  };
+
+  useEffect(() => {
+    loadOrders();
+  }, []);
+
   return (
-      <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
       <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.orders')}</h1>
+        <ul className="space-y-4">
+          {orders.map((order) => (
+            <li key={order.id} data-testid="client-order">
+              <OrderCard order={order} />
+            </li>
+          ))}
+        </ul>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add API helper to load client orders
- implement order card and page to list user deals
- extend i18n with order related translations

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a5df5d9bf08332929e4f763d0eba64