### PR TITLE
feat: manage client payment methods

### DIFF
--- a/src/api/clientPaymentMethods.ts
+++ b/src/api/clientPaymentMethods.ts
@@ -31,3 +31,16 @@ export function createClientPaymentMethod(data: CreateClientPaymentMethodPayload
     body: JSON.stringify(data),
   });
 }
+
+export function updateClientPaymentMethod(id: string, data: CreateClientPaymentMethodPayload) {
+  return apiRequest<ClientPaymentMethod>(`/client/payment-methods/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export function deleteClientPaymentMethod(id: string) {
+  return apiRequest<{ status: string }>(`/client/payment-methods/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -108,7 +108,12 @@
     "download": "Download",
     "settings": "Settings",
     "underDevelopment": "Section under development",
-    "logout": "Logout"
+    "logout": "Logout",
+    "personalSettings": "Personal settings",
+    "paymentMethods": "Payment methods",
+    "add": "Add",
+    "edit": "Edit",
+    "delete": "Delete"
   },
   "filters": {
     "title": "Filters",


### PR DESCRIPTION
## Summary
- add personal settings section with payment methods management dialog
- support creating, updating and deleting client payment methods via API

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5e6646e188332995b96f180a90b3a