### PR TITLE
Запрет создания ордера для собственного оффера

### DIFF
--- a/src/components/OfferCard.test.tsx
+++ b/src/components/OfferCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+import '../i18n';
+import { OfferCard } from './OfferCard';
+import { AuthProvider } from '@/context/AuthContext';
+
+const renderWithUser = (username: string, traderName: string) => {
+  localStorage.setItem(
+    'peerex_user_info',
+    JSON.stringify({ username, twofaEnabled: false, pinCodeSet: false }),
+  );
+  const offer = {
+    id: '1',
+    trader: { name: traderName, rating: 5, completedTrades: 10, online: true },
+    fromAsset: { name: 'USD' },
+    toAsset: { name: 'BTC' },
+    amount: '100',
+    price: '1',
+    paymentMethods: ['PayPal'],
+    limits: { min: '10', max: '100' },
+    type: 'buy' as const,
+  };
+  render(
+    <AuthProvider>
+      <OfferCard offer={offer} />
+    </AuthProvider>,
+  );
+};
+
+describe('OfferCard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('отключает кнопку для своего оффера', () => {
+    renderWithUser('Alice', 'Alice');
+    const btn = screen.getByRole('button', { name: /sell/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('включает кнопку для чужого оффера', () => {
+    renderWithUser('Alice', 'Bob');
+    const btn = screen.getByRole('button', { name: /sell/i });
+    expect(btn).not.toBeDisabled();
+  });
+});

--- a/src/components/OfferCard.tsx
+++ b/src/components/OfferCard.tsx
@@ -2,6 +2,7 @@ import { Star, Pencil, PowerOff } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 import { CreateOrderForm } from './CreateOrderForm';
+import { useAuth } from '@/context';
 
 interface OfferCardProps {
   offer: {
@@ -32,6 +33,7 @@ interface OfferCardProps {
 export const OfferCard = ({ offer, isClientOffer, onToggle, onEdit }: OfferCardProps) => {
   const { t } = useTranslation();
   const [showOrder, setShowOrder] = useState(false);
+  const { userInfo } = useAuth();
   const {
     id,
     trader,
@@ -48,6 +50,7 @@ export const OfferCard = ({ offer, isClientOffer, onToggle, onEdit }: OfferCardP
     TTL,
   } = offer;
 
+  const isOwnOffer = userInfo?.username === trader.name;
   const currency = `${fromAsset?.name}/${toAsset?.name}`;
 
   return (
@@ -166,8 +169,9 @@ export const OfferCard = ({ offer, isClientOffer, onToggle, onEdit }: OfferCardP
                           type === 'buy'
                               ? 'bg-green-600 hover:bg-green-700'
                               : 'bg-red-600 hover:bg-red-700'
-                      }`}
+                      } disabled:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed`}
                       onClick={() => setShowOrder(true)}
+                      disabled={isOwnOffer}
                   >
                     {type === 'buy' ? t('offerCard.sell') : t('offerCard.buy')}
                   </button>


### PR DESCRIPTION
## Summary
- запретил создавать ордер на собственные офферы и приглушил кнопку
- добавил тесты для проверки отключения кнопки

## Testing
- `npm run lint` *(failed: Unexpected any in существующих файлах)*
- `npx vitest run src/components/OfferCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a5e947c9a483329cfbf0c87c0c1b69