### PR TITLE
feat: split orders into my and ad deals pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,8 @@ import Recover from "./pages/Recover";
 import NotFound from "./pages/NotFound";
 import Balance from "./pages/Balance";
 import Adverts from "./pages/Adverts";
-import Orders from "./pages/Orders";
+import AdDeals from "./pages/AdDeals";
+import MyDeals from "./pages/MyDeals";
 import Transactions from "./pages/Transactions";
 import Escrow from "./pages/Escrow";
 import { ScrollToTopButton } from "./components/ScrollToTopButton";
@@ -33,7 +34,8 @@ const App = () => (
             <Route path="/recover" element={<Recover />} />
             <Route path="/balance" element={<Balance />} />
             <Route path="/adverts" element={<Adverts />} />
-            <Route path="/orders" element={<Orders />} />
+            <Route path="/my-deals" element={<MyDeals />} />
+            <Route path="/ad-deals" element={<AdDeals />} />
             <Route path="/transactions" element={<Transactions />} />
             <Route path="/escrow" element={<Escrow />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -52,9 +52,10 @@ export const Header = () => {
                         {/* Desktop navigation — пилюли как в фильтрах (только для авторизованных) */}
                         {isAuthenticated && (
                             <nav className="hidden md:flex items-center gap-2">
-                                <NavItem to="/adverts" label={t('header.adverts')}/>
-                                <NavItem to="/orders" label={t('header.orders')}/>
-                                <NavItem to="/transactions" label={t('header.transactions')}/>
+                                <NavItem to="/adverts" label={t('header.adverts')} />
+                                <NavItem to="/my-deals" label={t('header.myDeals')} />
+                                <NavItem to="/ad-deals" label={t('header.adDeals')} />
+                                <NavItem to="/transactions" label={t('header.transactions')} />
                                 <NavItem to="/balance" label={t('header.balance')}/>
                                 <NavItem to="/escrow" label={t('header.escrow')}/>
                             </nav>
@@ -130,15 +131,17 @@ export const Header = () => {
                                 {isAuthenticated && (
                                     <>
                                         <NavItem to="/adverts" label={t('header.adverts')}
-                                                 onClick={() => setIsMenuOpen(false)}/>
-                                        <NavItem to="/orders" label={t('header.orders')}
-                                                 onClick={() => setIsMenuOpen(false)}/>
+                                                 onClick={() => setIsMenuOpen(false)} />
+                                        <NavItem to="/my-deals" label={t('header.myDeals')}
+                                                 onClick={() => setIsMenuOpen(false)} />
+                                        <NavItem to="/ad-deals" label={t('header.adDeals')}
+                                                 onClick={() => setIsMenuOpen(false)} />
                                         <NavItem to="/transactions" label={t('header.transactions')}
-                                                 onClick={() => setIsMenuOpen(false)}/>
+                                                 onClick={() => setIsMenuOpen(false)} />
                                         <NavItem to="/balance" label={t('header.balance')}
-                                                 onClick={() => setIsMenuOpen(false)}/>
+                                                 onClick={() => setIsMenuOpen(false)} />
                                         <NavItem to="/escrow" label={t('header.escrow')}
-                                                 onClick={() => setIsMenuOpen(false)}/>
+                                                 onClick={() => setIsMenuOpen(false)} />
                                     </>
                                 )}
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -7,7 +7,8 @@
     "history": "History",
     "balance": "Balance",
     "adverts": "Adverts",
-    "orders": "Orders",
+    "myDeals": "My Deals",
+    "adDeals": "Ad Deals",
     "transactions": "Transactions",
     "escrow": "Escrow"
   },

--- a/src/pages/AdDeals.tsx
+++ b/src/pages/AdDeals.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { Header } from '@/components/Header';
+import { useTranslation } from 'react-i18next';
+import { getClientOrders, type OrderFull } from '@/api/orders';
+import { OrderCard } from '@/components/OrderCard';
+
+const AdDeals = () => {
+  const { t } = useTranslation();
+  const [orders, setOrders] = useState<OrderFull[]>([]);
+
+  const loadOrders = async () => {
+    try {
+      const data = await getClientOrders('author');
+      const sorted = [...data].sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      );
+      setOrders(sorted);
+    } catch (err) {
+      console.error('load client orders error:', err);
+      setOrders([]);
+    }
+  };
+
+  useEffect(() => {
+    loadOrders();
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
+      <Header />
+      <div className="container mx-auto px-4 pt-24 pb-8">
+        <h1 className="text-2xl font-bold mb-4">{t('header.adDeals')}</h1>
+        <ul className="space-y-4">
+          {orders.map((order) => (
+            <li key={order.id} data-testid="client-order">
+              <OrderCard order={order} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default AdDeals;

--- a/src/pages/MyDeals.tsx
+++ b/src/pages/MyDeals.tsx
@@ -4,13 +4,13 @@ import { useTranslation } from 'react-i18next';
 import { getClientOrders, type OrderFull } from '@/api/orders';
 import { OrderCard } from '@/components/OrderCard';
 
-const Orders = () => {
+const MyDeals = () => {
   const { t } = useTranslation();
   const [orders, setOrders] = useState<OrderFull[]>([]);
 
   const loadOrders = async () => {
     try {
-      const data = await getClientOrders('author');
+      const data = await getClientOrders('offerOwner');
       const sorted = [...data].sort(
         (a, b) =>
           new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
@@ -30,7 +30,7 @@ const Orders = () => {
     <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
       <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
-        <h1 className="text-2xl font-bold mb-4">{t('header.orders')}</h1>
+        <h1 className="text-2xl font-bold mb-4">{t('header.myDeals')}</h1>
         <ul className="space-y-4">
           {orders.map((order) => (
             <li key={order.id} data-testid="client-order">
@@ -43,4 +43,4 @@ const Orders = () => {
   );
 };
 
-export default Orders;
+export default MyDeals;


### PR DESCRIPTION
## Summary
- add AdDeals page for author orders
- add MyDeals page for offer owner orders
- update routes, header navigation and translations

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5efc363a08332a1698ffe97845748