### PR TITLE
Предотвращение закрытия форм ProfileDrawer и улучшение кнопки Close

### DIFF
--- a/src/components/ProfileDrawer.tsx
+++ b/src/components/ProfileDrawer.tsx
@@ -34,7 +34,7 @@ import {
 } from '@/api';
 import { useAuth } from '@/context';
 import { useTranslation } from 'react-i18next';
-import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { clearTwoFactorEnabled, loadTwoFactorEnabled, saveTwoFactorEnabled } from '@/storage/two_factor';
 
@@ -62,7 +62,11 @@ interface ModalContentProps {
 }
 
 const ModalContent = ({ children, title, error }: ModalContentProps) => (
-  <DialogContent className="bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white sm:max-w-lg w-[calc(100vw-2rem)] rounded-2xl border border-white/10 shadow-2xl p-0 overflow-hidden">
+  <DialogContent
+      className="bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white sm:max-w-lg w-[calc(100vw-2rem)] rounded-2xl border border-white/10 shadow-2xl p-0 overflow-hidden"
+      onEscapeKeyDown={(e) => e.preventDefault()}
+      onInteractOutside={(e) => e.preventDefault()}
+  >
     <DialogHeader className="px-5 pt-5">
       <DialogTitle className="text-lg font-semibold tracking-tight">{title}</DialogTitle>
     </DialogHeader>
@@ -312,8 +316,9 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
         <SheetContent
             side="right"
             className="text-white h-full bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 border-l border-white/10 p-0"
+            onEscapeKeyDown={(e) => e.preventDefault()}
+            onInteractOutside={(e) => e.preventDefault()}
         >
-          <SheetClose className="absolute right-4 top-4 rounded-full bg-white/5 p-1 text-white/70 ring-1 ring-white/10 hover:bg-white/10 hover:text-white" />
 
           {/* Header */}
           <div className="px-5 pt-6 pb-4 border-b border-white/10 backdrop-blur">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -42,8 +42,8 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-white/5 p-2 text-white/70 ring-1 ring-white/10 transition hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/20">
+        <X className="h-5 w-5" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -63,8 +63,8 @@ const SheetContent = React.forwardRef<
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <X className="h-4 w-4" />
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-full bg-white/5 p-2 text-white/70 ring-1 ring-white/10 transition hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-white/20">
+        <X className="h-5 w-5" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>


### PR DESCRIPTION
## Summary
- запрещено закрытие форм ProfileDrawer по клику вне формы или по Esc
- увеличен и стилизован значок закрытия в модалках и профиле

## Testing
- `CI=1 npm test`
- `npm run lint` *(fail: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ad927a90a08332bd946cda75a2fdb6