### PR TITLE
Выбор метода оплаты из оффера при создании ордера

### DIFF
--- a/src/components/CreateOrderForm.tsx
+++ b/src/components/CreateOrderForm.tsx
@@ -1,13 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from '@/components/ui/sonner';
 import { createOrder } from '@/api/orders';
-import { getClientPaymentMethods, ClientPaymentMethod } from '@/api/clientPaymentMethods';
+import type { ClientPaymentMethod } from '@/api/clientPaymentMethods';
 
 interface CreateOrderFormProps {
   offerId: string;
   limits: { min: string; max: string };
+  paymentMethods: ClientPaymentMethod[];
   onClose: () => void;
 }
 
@@ -20,27 +21,19 @@ const btnSoft =
   'inline-flex items-center gap-2 rounded-xl bg-white/5 px-3 py-2 text-sm font-medium text-white/80 ring-1 ring-white/10 hover:bg-white/10 hover:ring-white/20 transition';
 const sectionCard = 'rounded-2xl border border-white/10 bg-gray-900/60 p-4';
 
-export const CreateOrderForm = ({ offerId, limits, onClose }: CreateOrderFormProps) => {
+export const CreateOrderForm = ({
+  offerId,
+  limits,
+  paymentMethods,
+  onClose,
+}: CreateOrderFormProps) => {
   const { t } = useTranslation();
-  const [paymentMethods, setPaymentMethods] = useState<ClientPaymentMethod[]>([]);
   const [formData, setFormData] = useState({
     amount: '',
     clientPaymentMethodId: '',
     pinCode: '',
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
-
-  useEffect(() => {
-    async function load() {
-      try {
-        const methods = await getClientPaymentMethods();
-        setPaymentMethods(methods);
-      } catch (err) {
-        console.error('load methods error:', err);
-      }
-    }
-    load();
-  }, []);
 
   const validate = () => {
     const e: Record<string, string> = {};

--- a/src/components/OfferCard.test.tsx
+++ b/src/components/OfferCard.test.tsx
@@ -16,7 +16,7 @@ const renderWithUser = (username: string, traderName: string) => {
     toAsset: { name: 'BTC' },
     amount: '100',
     price: '1',
-    paymentMethods: ['PayPal'],
+    paymentMethods: [{ id: '1', name: 'PayPal' }],
     limits: { min: '10', max: '100' },
     type: 'buy' as const,
   };

--- a/src/components/OfferCard.tsx
+++ b/src/components/OfferCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useState } from 'react';
 import { CreateOrderForm } from './CreateOrderForm';
 import { useAuth } from '@/context';
+import type { ClientPaymentMethod } from '@/api/clientPaymentMethods';
 
 interface OfferCardProps {
   offer: {
@@ -17,7 +18,7 @@ interface OfferCardProps {
     toAsset: { name: string };
     amount: string;
     price: string;
-    paymentMethods: string[];
+    paymentMethods: ClientPaymentMethod[];
     limits: { min: string; max: string };
     type: 'buy' | 'sell';
     isEnabled?: boolean;
@@ -106,13 +107,13 @@ export const OfferCard = ({ offer, isClientOffer, onToggle, onEdit }: OfferCardP
             <div className="mt-4">
               <p className="text-xs text-white/60 mb-2">{t('offerCard.paymentMethods')}</p>
               <div className="flex flex-wrap gap-2">
-                {paymentMethods.map((method, index) => (
-                    <span
-                        key={index}
-                        className="px-2 py-1 rounded-full bg-white/10 text-white/70 text-xs ring-1 ring-white/10"
-                    >
-                  {method}
-                </span>
+                {paymentMethods.map((method) => (
+                  <span
+                    key={method.id ?? method.ID}
+                    className="px-2 py-1 rounded-full bg-white/10 text-white/70 text-xs ring-1 ring-white/10"
+                  >
+                    {method.paymentMethod?.name ?? method.name ?? ''}
+                  </span>
                 ))}
               </div>
             </div>
@@ -184,6 +185,7 @@ export const OfferCard = ({ offer, isClientOffer, onToggle, onEdit }: OfferCardP
         <CreateOrderForm
           offerId={id}
           limits={limits}
+          paymentMethods={paymentMethods}
           onClose={() => setShowOrder(false)}
         />
       )}

--- a/src/components/OfferList.tsx
+++ b/src/components/OfferList.tsx
@@ -28,7 +28,7 @@ interface OfferItem {
   toAsset: { name: string };
   amount: string;
   price: string;
-  paymentMethods: string[];
+  paymentMethods: ClientPaymentMethod[];
   limits: { min: string; max: string };
   type: 'buy' | 'sell';
   isEnabled?: boolean;
@@ -65,12 +65,7 @@ export const OfferList = ({ type, filters }: OfferListProps) => {
           toAsset: o.toAsset ?? { name: o.toAssetID },
           amount: String(o.amount),
           price: String(o.price),
-          paymentMethods:
-            o.clientPaymentMethods?.map(
-              (m: ClientPaymentMethod) =>
-                m.paymentMethod?.name ?? m.name ?? '',
-            )
-              .filter(Boolean) ?? [],
+          paymentMethods: o.clientPaymentMethods ?? [],
           limits: { min: String(o.minAmount), max: String(o.maxAmount) },
           type,
           isEnabled: o.isEnabled,

--- a/src/pages/Adverts.tsx
+++ b/src/pages/Adverts.tsx
@@ -7,7 +7,6 @@ import {
   enableOffer,
   disableOffer,
 } from '@/api/offers';
-import type { ClientPaymentMethod } from '@/api/clientPaymentMethods';
 import { OfferCard } from '@/components/OfferCard';
 import { CreateOfferForm } from '@/components/CreateOfferForm';
 
@@ -68,12 +67,7 @@ const Adverts = () => {
                   toAsset: { name: offer.toAsset?.name || offer.toAssetID },
                   amount: String(offer.amount),
                   price: String(offer.price),
-                  paymentMethods:
-                    offer.clientPaymentMethods?.map(
-                      (m: ClientPaymentMethod) =>
-                        m.paymentMethod?.name ?? m.name ?? '',
-                    )
-                      .filter(Boolean) ?? [],
+                  paymentMethods: offer.clientPaymentMethods ?? [],
                   limits: {
                     min: String(offer.minAmount),
                     max: String(offer.maxAmount),


### PR DESCRIPTION
## Изменения
- Передача методов оплаты из оффера в форму создания ордера
- Отображение и выбор методов оплаты только из списка оффера
- Корректировка типов и тестов для новой структуры

## Тестирование
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9d2ab0f48332ac0331fc161ffa33