### PR TITLE
feat: invert offer types for listings

### DIFF
--- a/src/components/OfferList.test.tsx
+++ b/src/components/OfferList.test.tsx
@@ -20,7 +20,9 @@ describe('OfferList', () => {
   it('запрашивает офферы при монтировании', async () => {
     render(<OfferList type="buy" filters={baseFilters} />);
     await waitFor(() => {
-      expect(getOffers).toHaveBeenCalled();
+      expect(getOffers).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'sell' }),
+      );
     });
   });
 
@@ -28,10 +30,18 @@ describe('OfferList', () => {
     const { rerender } = render(
       <OfferList type="buy" filters={baseFilters} />,
     );
-    await waitFor(() => expect(getOffers).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getOffers).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'sell' }),
+      ),
+    );
     (getOffers as unknown as ReturnType<typeof vi.fn>).mockClear();
     const newFilters = { ...baseFilters, minAmount: '10' };
     rerender(<OfferList type="buy" filters={newFilters} />);
-    await waitFor(() => expect(getOffers).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(getOffers).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'sell' }),
+      ),
+    );
   });
 });

--- a/src/components/OfferList.tsx
+++ b/src/components/OfferList.tsx
@@ -40,6 +40,8 @@ interface OfferItem {
 export const OfferList = ({ type, filters }: OfferListProps) => {
   const [offers, setOffers] = useState<OfferItem[]>([]);
 
+  const queryType = type === 'buy' ? 'sell' : 'buy';
+
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -50,7 +52,7 @@ export const OfferList = ({ type, filters }: OfferListProps) => {
           min_amount: filters.minAmount,
           max_amount: filters.maxAmount,
           payment_method: filters.paymentMethod,
-          type,
+          type: queryType,
         });
         if (cancelled) return;
         const mapped = offers.map((o) => ({
@@ -67,7 +69,7 @@ export const OfferList = ({ type, filters }: OfferListProps) => {
           price: String(o.price),
           paymentMethods: o.clientPaymentMethods ?? [],
           limits: { min: String(o.minAmount), max: String(o.maxAmount) },
-          type,
+          type: o.type as 'buy' | 'sell',
           isEnabled: o.isEnabled,
           conditions: o.conditions,
           offerExpirationTimeout: o.orderExpirationTimeout,
@@ -82,7 +84,7 @@ export const OfferList = ({ type, filters }: OfferListProps) => {
     return () => {
       cancelled = true;
     };
-  }, [type, filters]);
+  }, [queryType, filters]);
 
   const { t } = useTranslation();
 
@@ -90,7 +92,7 @@ export const OfferList = ({ type, filters }: OfferListProps) => {
     <div className="space-y-4">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-white">
-          {type === "buy" ? t("offers.buy") : t("offers.sell")}
+          {queryType === "buy" ? t("offers.buy") : t("offers.sell")}
         </h3>
         <span className="text-sm text-gray-400">
           {offers.length} {t('offers.found')}


### PR DESCRIPTION
## Summary
- invert offer type when fetching and displaying offers
- cover inverted logic in OfferList tests

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1b17af88332ae2a5b00c5cdf7a8