### PR TITLE
feat: обновление офферов через WebSocket

### DIFF
--- a/src/components/OfferList.test.tsx
+++ b/src/components/OfferList.test.tsx
@@ -8,6 +8,10 @@ vi.mock('@/api/offers', () => ({
   getOffers: vi.fn().mockResolvedValue([]),
 }));
 
+vi.mock('@/context/AuthContext', () => ({
+  useAuth: () => ({ tokens: null }),
+}));
+
 describe('OfferList', () => {
   const baseFilters = {
     fromAsset: 'all',

--- a/src/hooks/use-offers-ws.ts
+++ b/src/hooks/use-offers-ws.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react';
+import type { Offer } from '@/api/offers';
+
+export interface OfferEvent {
+  type: string;
+  offer: Offer;
+}
+
+export function useOffersWS(
+  token: string | undefined,
+  onEvent: (event: OfferEvent) => void,
+) {
+  useEffect(() => {
+    if (!token) return;
+
+    const base = (import.meta.env.VITE_API_BASE_URL ?? '/api/v1')
+      .replace(/^http/, 'ws')
+      .replace(/\/$/, '');
+
+    const WS = WebSocket as unknown as {
+      new (
+        url: string,
+        protocols?: string | string[],
+        options?: { headers?: Record<string, string> },
+      ): WebSocket;
+    };
+
+    const ws = new WS(`${base}/ws/offers`, undefined, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    ws.onmessage = (evt) => {
+      const event: OfferEvent = JSON.parse(evt.data);
+      onEvent(event);
+    };
+    return () => ws.close();
+  }, [token, onEvent]);
+}


### PR DESCRIPTION
## Summary
- WebSocket подписка на офферы теперь передаёт токен в заголовке Authorization
## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68adad814c5883329bc5fb30ca015bf8