### PR TITLE
Запрет выбора одинаковых активов в фильтре

### DIFF
--- a/src/components/FilterPanel.test.tsx
+++ b/src/components/FilterPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { useState } from 'react';
 import userEvent from '@testing-library/user-event';
 import i18n from '../i18n';
 
@@ -61,6 +62,30 @@ describe('FilterPanel', () => {
       ...baseFilters,
       fromAsset: 'BTC'
     });
+  });
+
+  it('сбрасывает выбор при одинаковых активах', async () => {
+    const Wrapper = () => {
+      const [filters, setFilters] = useState(baseFilters);
+      return (
+        <FilterPanel
+          filters={filters}
+          onFiltersChange={setFilters}
+          activeTab="buy"
+          onTabChange={() => {}}
+        />
+      );
+    };
+
+    render(<Wrapper />);
+
+    const fromSelect = (await screen.findAllByTestId('from-asset'))[0];
+    const toSelect = (await screen.findAllByTestId('to-asset'))[0];
+
+    fireEvent.change(fromSelect, { target: { value: 'BTC' } });
+    fireEvent.change(toSelect, { target: { value: 'BTC' } });
+
+    expect(toSelect).toHaveValue('all');
   });
 
   it('вызывает onFiltersChange при смене метода оплаты', async () => {

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -89,7 +89,17 @@ export const FilterPanel = ({
     };
   }, [allOption, allMethodsOption]);
 
-  const change = (patch: Partial<FilterPanelProps['filters']>) => onFiltersChange({ ...filters, ...patch });
+  const change = (patch: Partial<FilterPanelProps['filters']>) => {
+    const next = { ...filters, ...patch };
+    if (next.fromAsset !== 'all' && next.fromAsset === next.toAsset) {
+      if (patch.fromAsset && !patch.toAsset) {
+        next.fromAsset = 'all';
+      } else {
+        next.toAsset = 'all';
+      }
+    }
+    onFiltersChange(next);
+  };
 
   // NEW: счётчик активных фильтров для бейджа
   const activeFiltersCount = useMemo(() => {


### PR DESCRIPTION
## Summary
- запрет одинаковых активов в FilterPanel: при повторе сбрасываем новый выбор
- добавлен тест на сброс дублирующего актива

## Testing
- `npm test -- --run`
- `npm run lint` *(errors: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68adbc2405e88332a916dac88f94a06f