### PR TITLE
feat: add websocket notifications with infinite scroll

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,3 +10,4 @@ export * from './clientAssets';
 export * from './wallets';
 export * from './transactions';
 export * from './orders';
+export * from './notifications';

--- a/src/api/notifications.ts
+++ b/src/api/notifications.ts
@@ -1,0 +1,23 @@
+import { apiRequest } from './client';
+
+export interface ApiNotification {
+  id: string;
+  createdAt: string;
+  readAt?: string;
+  type: string;
+  linkTo?: string;
+  payload?: Record<string, unknown>;
+}
+
+export async function listNotifications(limit: number, offset: number) {
+  const params = new URLSearchParams({ limit: String(limit), offset: String(offset) });
+  return apiRequest<ApiNotification[]>(`/notifications?${params.toString()}`);
+}
+
+export async function markNotificationRead(id: string) {
+  return apiRequest<ApiNotification>(`/notifications/${id}/read`, { method: 'POST' });
+}
+
+export async function markAllNotificationsRead() {
+  return apiRequest<unknown>(`/notifications/read-all`, { method: 'POST' });
+}

--- a/src/components/Header.test.tsx
+++ b/src/components/Header.test.tsx
@@ -7,6 +7,18 @@ import '../i18n';
 const authState = { isAuthenticated: false };
 vi.mock('@/context', () => ({ useAuth: () => authState }));
 vi.mock('./ProfileDrawer', () => ({ ProfileDrawer: () => <div>drawer</div> }));
+const notificationsState = {
+  items: [],
+  unreadCount: 0,
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+  loadMore: vi.fn(),
+  hasMore: false,
+  loading: false,
+};
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: () => notificationsState,
+}));
 
 describe('Header component', () => {
   afterEach(() => {

--- a/src/components/notifications/NotificationsModal.tsx
+++ b/src/components/notifications/NotificationsModal.tsx
@@ -1,0 +1,155 @@
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { X } from 'lucide-react';
+import type { NotificationItem } from '@/hooks/useNotifications';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  items: NotificationItem[];
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  loadMore: () => void;
+  hasMore: boolean;
+  loading: boolean;
+}
+
+export function NotificationsModal({
+  open,
+  onClose,
+  items,
+  markAsRead,
+  markAllAsRead,
+  loadMore,
+  hasMore,
+  loading,
+}: Props) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === 'Escape' && onClose();
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleItemClick = (n: NotificationItem) => {
+    markAsRead(n.id);
+    if (n.linkTo) navigate(n.linkTo);
+    onClose();
+  };
+
+  const handleScroll: React.UIEventHandler<HTMLDivElement> = (e) => {
+    const el = e.currentTarget;
+    if (hasMore && !loading && el.scrollTop + el.clientHeight >= el.scrollHeight - 20) {
+      loadMore();
+    }
+  };
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-[70] bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+        data-testid="notifications-backdrop"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        className="fixed inset-0 z-[71] grid place-items-center p-4"
+      >
+        <div className="relative w-full max-w-lg rounded-2xl border border-white/10 bg-gray-900/90 backdrop-blur ring-1 ring-white/10 shadow-2xl">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-white/70">
+                {t('notifications.title', 'Уведомления')}
+              </span>
+              {items.some((i) => !i.isRead) && (
+                <button
+                  onClick={markAllAsRead}
+                  className="rounded-lg px-2 py-1 text-xs bg-white/5 text-white/70 ring-1 ring-white/10 hover:bg-white/10 hover:text-white transition"
+                >
+                  {t('notifications.markAllRead', 'Отметить все прочитанными')}
+                </button>
+              )}
+            </div>
+            <button
+              onClick={onClose}
+              className="rounded-lg p-1 text-white/70 hover:bg-white/5 hover:text-white transition"
+              aria-label={t('notifications.close', 'Закрыть')}
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          <div className="max-h-[60vh] overflow-y-auto p-2" onScroll={handleScroll}>
+            {items.length === 0 ? (
+              <div className="p-6 text-center text-white/60">
+                {t('notifications.empty', 'Пока уведомлений нет')}
+              </div>
+            ) : (
+              <ul className="divide-y divide-white/10">
+                {items.map((n) => (
+                  <li key={n.id}>
+                    <button
+                      onClick={() => handleItemClick(n)}
+                      className={[
+                        'w-full text-left px-4 py-3 transition flex items-start gap-3',
+                        'hover:bg-white/5',
+                        !n.isRead ? 'bg-emerald-400/5' : '',
+                      ].join(' ')}
+                    >
+                      <span
+                        className={[
+                          'mt-1 inline-flex h-2 w-2 rounded-full',
+                          n.isRead ? 'bg-white/20' : 'bg-emerald-400',
+                        ].join(' ')}
+                        aria-hidden
+                      />
+                      <div className="flex-1">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-medium text-white">{n.title}</p>
+                          <time
+                            className="shrink-0 text-[11px] text-white/50"
+                            dateTime={n.createdAt}
+                            title={new Date(n.createdAt).toLocaleString()}
+                          >
+                            {formatRelative(n.createdAt)}
+                          </time>
+                        </div>
+                        {n.body && (
+                          <p className="mt-1 text-sm text-white/70">{n.body}</p>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+            {loading && (
+              <div className="p-4 text-center text-white/60">
+                {t('notifications.loading', 'Загрузка...')}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function formatRelative(iso: string) {
+  const dt = new Date(iso).getTime();
+  const diff = Math.max(0, Date.now() - dt);
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return 'только что';
+  if (m < 60) return `${m} мин назад`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h} ч назад`;
+  const d = Math.floor(h / 24);
+  return `${d} дн назад`;
+}

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -1,0 +1,113 @@
+import { useAuth } from '@/context';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ApiNotification,
+  listNotifications,
+  markNotificationRead,
+  markAllNotificationsRead,
+} from '@/api/notifications';
+
+export interface NotificationItem {
+  id: string;
+  title: string;
+  body: string;
+  createdAt: string;
+  isRead: boolean;
+  linkTo?: string;
+}
+
+function mapNotification(n: ApiNotification): NotificationItem {
+  const payload = (n.payload ?? {}) as Record<string, unknown>;
+  return {
+    id: n.id,
+    title: String(payload.title ?? n.type),
+    body: String(payload.body ?? ''),
+    createdAt: n.createdAt,
+    isRead: !!n.readAt,
+    linkTo: (payload.linkTo as string | undefined) ?? n.linkTo,
+  };
+}
+
+const PAGE_SIZE = 20;
+
+export function useNotifications() {
+  const { tokens } = useAuth();
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const res = await listNotifications(PAGE_SIZE, offset);
+      const mapped = res.map(mapNotification);
+      setItems((prev) => [...prev, ...mapped]);
+      setOffset((prev) => prev + mapped.length);
+      if (res.length < PAGE_SIZE) {
+        setHasMore(false);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, hasMore, offset]);
+
+  useEffect(() => {
+    loadMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const token = tokens?.access;
+    if (!token) return;
+    const base = (import.meta.env.VITE_API_BASE_URL ?? '/api/v1')
+      .replace(/^http/, 'ws')
+      .replace(/\/$/, '');
+    const ws = new WebSocket(`${base}/ws/notifications?token=${token}`);
+    ws.onmessage = (evt) => {
+      try {
+        const data: ApiNotification = JSON.parse(evt.data);
+        setItems((prev) => [mapNotification(data), ...prev]);
+      } catch {
+        // ignore
+      }
+    };
+    return () => ws.close();
+  }, [tokens?.access]);
+
+  const markAsRead = useCallback(async (id: string) => {
+    try {
+      await markNotificationRead(id);
+    } catch {
+      // ignore
+    }
+    setItems((prev) => prev.map((n) => (n.id === id ? { ...n, isRead: true } : n)));
+  }, []);
+
+  const markAllAsRead = useCallback(async () => {
+    try {
+      await markAllNotificationsRead();
+    } catch {
+      // ignore
+    }
+    setItems((prev) => prev.map((n) => ({ ...n, isRead: true })));
+  }, []);
+
+  const unreadCount = useMemo(
+    () => items.reduce((acc, n) => acc + (n.isRead ? 0 : 1), 0),
+    [items],
+  );
+
+  return {
+    items,
+    unreadCount,
+    markAsRead,
+    markAllAsRead,
+    loadMore,
+    hasMore,
+    loading,
+  };
+}


### PR DESCRIPTION
## Summary
- add notification API helpers
- add notifications hook with websocket and pagination
- show notifications in modal with infinite scroll

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68add743a38c83329b33cfddfd7419f2