### PR TITLE
Добавлен переход на страницу ордера с чатом

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,9 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthProvider } from "@/context/AuthContext";
+import { AuthProvider, useAuth } from "@/context/AuthContext";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { useMemo } from "react";
 import Index from "./pages/Index";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
@@ -18,8 +19,15 @@ import Transactions from "./pages/Transactions";
 import Escrow from "./pages/Escrow";
 import { ScrollToTopButton } from "./components/ScrollToTopButton";
 import OrderItem from '@/pages/OrderItem';
+import { getUserIdFromToken } from '@/lib/jwt';
 
 const queryClient = new QueryClient();
+
+const OrderItemRoute = () => {
+  const { tokens } = useAuth();
+  const uid = useMemo(() => getUserIdFromToken(tokens?.access) ?? '', [tokens]);
+  return <OrderItem token={tokens?.access} currentUserID={uid} />;
+};
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -39,6 +47,7 @@ const App = () => (
             <Route path="/ad-deals" element={<AdDeals />} />
             <Route path="/transactions" element={<Transactions />} />
             <Route path="/escrow" element={<Escrow />} />
+            <Route path="/orders/:id" element={<OrderItemRoute />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -82,3 +82,7 @@ export function createOrder(data: CreateOrderPayload) {
 export function getClientOrders(role: 'author' | 'offerOwner' = 'author') {
   return apiRequest<OrderFull[]>(`/client/orders?role=${role}`);
 }
+
+export function getOrder(id: string) {
+  return apiRequest<OrderFull>(`/orders/${id}`);
+}

--- a/src/lib/jwt.ts
+++ b/src/lib/jwt.ts
@@ -1,0 +1,13 @@
+export function getUserIdFromToken(token?: string): string | null {
+  if (!token) return null;
+  try {
+    const base64 = token.split('.')[1];
+    const json = typeof atob === 'function'
+      ? atob(base64)
+      : Buffer.from(base64, 'base64').toString('utf-8');
+    const payload = JSON.parse(json);
+    return payload.sub ?? payload.id ?? null;
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/OrderItem.tsx
+++ b/src/pages/OrderItem.tsx
@@ -2,18 +2,10 @@ import { useEffect, useMemo, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, ShieldCheck, Clock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import type { OrderFull } from '@/api/orders';
+import { getOrder, type OrderFull } from '@/api/orders';
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { cn } from '@/lib/utils';
 
-// Заглушка: замени на свой API-клиент
-async function fetchOrder(id: string): Promise<OrderFull> {
-    const res = await fetch(`${import.meta.env.VITE_API_BASE_URL ?? '/api/v1'}/orders/${id}`, {
-        credentials: 'include',
-    });
-    if (!res.ok) throw new Error('Failed to load order');
-    return res.json();
-}
 
 function useCountdown(expiresAt?: string | null) {
     const [left, setLeft] = useState<number>(() => {
@@ -58,7 +50,7 @@ export default function OrderItem({
     useEffect(() => {
         let mounted = true;
         setLoading(true);
-        fetchOrder(id)
+        getOrder(id)
             .then((o) => {
                 if (mounted) {
                     setOrder(o);


### PR DESCRIPTION
## Summary
- реализован API-метод получения ордера и маршрут страницы ордера
- добавлена утилита для извлечения ID пользователя из JWT
- страница OrderItem использует API и содержит панель чата

## Testing
- `npm run lint` (failed: Unexpected any in существующих файлах)
- `npx eslint src/App.tsx src/api/orders.ts src/pages/OrderItem.tsx src/lib/jwt.ts`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add7e100248332b082ff2d254f0d15