### PR TITLE
Добавлен переход на страницу ордера с чатом

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { AuthProvider } from "@/context/AuthContext";
+import { AuthProvider, useAuth } from "@/context/AuthContext";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import Login from "./pages/Login";
@@ -20,6 +20,11 @@ import { ScrollToTopButton } from "./components/ScrollToTopButton";
 import OrderItem from '@/pages/OrderItem';
 
 const queryClient = new QueryClient();
+
+const OrderItemRoute = () => {
+  const { tokens, userInfo } = useAuth();
+  return <OrderItem token={tokens?.access} currentUserName={userInfo?.username ?? ''} />;
+};
 
 const App = () => (
   <QueryClientProvider client={queryClient}>
@@ -39,6 +44,7 @@ const App = () => (
             <Route path="/ad-deals" element={<AdDeals />} />
             <Route path="/transactions" element={<Transactions />} />
             <Route path="/escrow" element={<Escrow />} />
+            <Route path="/orders/:id" element={<OrderItemRoute />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -82,3 +82,7 @@ export function createOrder(data: CreateOrderPayload) {
 export function getClientOrders(role: 'author' | 'offerOwner' = 'author') {
   return apiRequest<OrderFull[]>(`/client/orders?role=${role}`);
 }
+
+export function getOrder(id: string) {
+  return apiRequest<OrderFull>(`/orders/${id}`);
+}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -7,11 +7,11 @@ import { MessageBubble } from './MessageBubble';
 export function ChatPanel({
                               orderId,
                               token,
-                              currentUserID,
+                              currentUserName,
                           }: {
     orderId: string;
     token?: string;
-    currentUserID: string;
+    currentUserName: string;
 }) {
     const { t } = useTranslation();
     const { messages, isConnected, sendMessage } = useOrderChat(orderId, token);
@@ -64,7 +64,7 @@ export function ChatPanel({
                         key={m.id}
                         body={m.body}
                         senderName={m.senderName}
-                        isMe={m.senderId === currentUserID}
+                        isMe={m.senderName === currentUserName}
                         createdAt={m.createdAt}
                     />
                 ))}


### PR DESCRIPTION
## Summary
- реализован API-метод получения ордера и маршрут страницы ордера
- вместо разбора JWT используется имя пользователя из контекста авторизации
- панель чата сопоставляет сообщения с текущим пользователем по имени

## Testing
- `npm run lint` (failed: Unexpected any)
- `npx eslint src/App.tsx src/components/chat/ChatPanel.tsx src/pages/OrderItem.tsx`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68add7e100248332b082ff2d254f0d15