### PR TITLE
Исправление повторной подписки на WS и локализация уведомлений

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -98,14 +98,14 @@ export const Header = () => {
                                     <button
                                         onClick={() => setIsNotifOpen(true)}
                                         className="group relative rounded-xl h-9 w-9 grid place-items-center bg-white/5 text-white/80 ring-1 ring-white/10 transition hover:bg-white/10 hover:text-white"
-                                        aria-label={t('notifications.open', 'Открыть уведомления')}
+                                        aria-label={t('notifications.open', 'Open notifications')}
                                     >
                                         <Bell size={18}/>
                                         {/* Бейдж с количеством непрочитанных (только если > 0) */}
                                         {unreadCount > 0 && (
                                             <span
                                                 className="absolute -right-1 -top-1 min-w-[18px] h-[18px] px-1 grid place-items-center rounded-full text-[11px] font-semibold bg-emerald-400 text-gray-900"
-                                                aria-label={t('notifications.unreadCount', {defaultValue: '{{count}} неп.', count: unreadCount})}
+                                                aria-label={t('notifications.unreadCount', {defaultValue: '{{count}} unread', count: unreadCount})}
                                             >
                         {unreadCount > 99 ? '99+' : unreadCount}
                       </span>

--- a/src/components/notifications/NotificationsModal.tsx
+++ b/src/components/notifications/NotificationsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import type { TFunction } from 'i18next';
 import { useNavigate } from 'react-router-dom';
 import { X } from 'lucide-react';
 import type { NotificationItem } from '@/hooks/useNotifications';
@@ -66,21 +67,21 @@ export function NotificationsModal({
           <div className="flex items-center justify-between px-4 py-3 border-b border-white/10">
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-white/70">
-                {t('notifications.title', 'Уведомления')}
+                {t('notifications.title', 'Notifications')}
               </span>
               {items.some((i) => !i.isRead) && (
                 <button
                   onClick={markAllAsRead}
                   className="rounded-lg px-2 py-1 text-xs bg-white/5 text-white/70 ring-1 ring-white/10 hover:bg-white/10 hover:text-white transition"
                 >
-                  {t('notifications.markAllRead', 'Отметить все прочитанными')}
+                  {t('notifications.markAllRead', 'Mark all as read')}
                 </button>
               )}
             </div>
             <button
               onClick={onClose}
               className="rounded-lg p-1 text-white/70 hover:bg-white/5 hover:text-white transition"
-              aria-label={t('notifications.close', 'Закрыть')}
+              aria-label={t('notifications.close', 'Close')}
             >
               <X size={18} />
             </button>
@@ -89,7 +90,7 @@ export function NotificationsModal({
           <div className="max-h-[60vh] overflow-y-auto p-2" onScroll={handleScroll}>
             {items.length === 0 ? (
               <div className="p-6 text-center text-white/60">
-                {t('notifications.empty', 'Пока уведомлений нет')}
+                {t('notifications.empty', 'No notifications yet')}
               </div>
             ) : (
               <ul className="divide-y divide-white/10">
@@ -118,7 +119,7 @@ export function NotificationsModal({
                             dateTime={n.createdAt}
                             title={new Date(n.createdAt).toLocaleString()}
                           >
-                            {formatRelative(n.createdAt)}
+                            {formatRelative(n.createdAt, t)}
                           </time>
                         </div>
                         {n.body && (
@@ -132,7 +133,7 @@ export function NotificationsModal({
             )}
             {loading && (
               <div className="p-4 text-center text-white/60">
-                {t('notifications.loading', 'Загрузка...')}
+                {t('notifications.loading', 'Loading...')}
               </div>
             )}
           </div>
@@ -142,14 +143,25 @@ export function NotificationsModal({
   );
 }
 
-function formatRelative(iso: string) {
+function formatRelative(iso: string, t: TFunction) {
   const dt = new Date(iso).getTime();
   const diff = Math.max(0, Date.now() - dt);
   const m = Math.floor(diff / 60_000);
-  if (m < 1) return 'только что';
-  if (m < 60) return `${m} мин назад`;
+  if (m < 1) return t('notifications.justNow', 'just now');
+  if (m < 60)
+    return t('notifications.minutesAgo', {
+      count: m,
+      defaultValue: '{{count}} min ago',
+    });
   const h = Math.floor(m / 60);
-  if (h < 24) return `${h} ч назад`;
+  if (h < 24)
+    return t('notifications.hoursAgo', {
+      count: h,
+      defaultValue: '{{count}} h ago',
+    });
   const d = Math.floor(h / 24);
-  return `${d} дн назад`;
+  return t('notifications.daysAgo', {
+    count: d,
+    defaultValue: '{{count}} d ago',
+  });
 }

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -35,7 +35,12 @@ let wsToken: string | null = null;
 const listeners = new Set<(n: ApiNotification) => void>();
 
 function connect(token: string) {
-  if (ws && wsToken === token) return;
+  if (
+    ws &&
+    wsToken === token &&
+    (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)
+  )
+    return;
   if (ws) ws.close();
   wsToken = token;
   const base = (import.meta.env.VITE_API_BASE_URL ?? '/api/v1')
@@ -49,6 +54,10 @@ function connect(token: string) {
     } catch {
       // ignore
     }
+  };
+  ws.onclose = () => {
+    ws = null;
+    wsToken = null;
   };
 }
 

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -83,6 +83,19 @@
     "oops": "Oops! Page not found",
     "returnHome": "Return to Home"
   },
+  "notifications": {
+    "title": "Notifications",
+    "markAllRead": "Mark all as read",
+    "close": "Close",
+    "empty": "No notifications yet",
+    "loading": "Loading...",
+    "open": "Open notifications",
+    "unreadCount": "{{count}} unread",
+    "justNow": "just now",
+    "minutesAgo": "{{count}} min ago",
+    "hoursAgo": "{{count}} h ago",
+    "daysAgo": "{{count}} d ago"
+  },
   "profile": {
     "title": "Profile",
     "changePassword": "Change password",


### PR DESCRIPTION
## Summary
- исключён повторный коннект к websocket при навигации
- добавлены английские языковые ключи для интерфейса уведомлений

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68ade151f3348332a8bff0669bcd9b6a