### PR TITLE
Запрос уведомлений только после входа пользователя

### DIFF
--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+vi.mock('@/context', () => ({ useAuth: () => ({ tokens: null }) }));
+vi.mock('@/api/notifications', () => ({
+  listNotifications: vi.fn().mockResolvedValue([]),
+  markNotificationRead: vi.fn(),
+  markAllNotificationsRead: vi.fn(),
+}));
+
+import { listNotifications } from '@/api/notifications';
+import { useNotifications } from './useNotifications';
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useNotifications', () => {
+  it('не запрашивает уведомления без токена', () => {
+    renderHook(() => useNotifications());
+    expect(listNotifications).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -87,7 +87,7 @@ export function useNotifications() {
   const [loading, setLoading] = useState(false);
 
   const loadMore = useCallback(async () => {
-    if (loading || !hasMore) return;
+    if (loading || !hasMore || !tokens?.access) return;
     setLoading(true);
     try {
       const res = await listNotifications(PAGE_SIZE, offset);
@@ -102,12 +102,16 @@ export function useNotifications() {
     } finally {
       setLoading(false);
     }
-  }, [loading, hasMore, offset]);
+  }, [loading, hasMore, offset, tokens?.access]);
 
   useEffect(() => {
+    setItems([]);
+    setOffset(0);
+    setHasMore(true);
+    if (!tokens?.access) return;
     loadMore();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [tokens?.access]);
 
   useEffect(() => {
     const token = tokens?.access;


### PR DESCRIPTION
## Summary
- не запрашиваем уведомления без токена
- добавлен тест на отсутствие запроса нотификаций для гостя

## Testing
- `npm test`
- `npm run lint` *(fail: Unexpected any и другие ошибки в существующем коде)*

------
https://chatgpt.com/codex/tasks/task_e_68aedef6605c833289ed8705d77d2746