### PR TITLE
Фикс постоянного обновления токена при навигации

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import Transactions from "./pages/Transactions";
 import Escrow from "./pages/Escrow";
 import { ScrollToTopButton } from "./components/ScrollToTopButton";
 import OrderItem from '@/pages/OrderItem';
+import MainLayout from "./components/MainLayout";
 
 const queryClient = new QueryClient();
 
@@ -34,17 +35,19 @@ const App = () => (
       <AuthProvider>
         <BrowserRouter>
           <Routes>
-            <Route path="/" element={<Index />} />
+            <Route element={<MainLayout />}>
+              <Route path="/" element={<Index />} />
+              <Route path="/balance" element={<Balance />} />
+              <Route path="/adverts" element={<Adverts />} />
+              <Route path="/my-deals" element={<MyDeals />} />
+              <Route path="/ad-deals" element={<AdDeals />} />
+              <Route path="/transactions" element={<Transactions />} />
+              <Route path="/escrow" element={<Escrow />} />
+              <Route path="/orders/:id" element={<OrderItemRoute />} />
+            </Route>
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/recover" element={<Recover />} />
-            <Route path="/balance" element={<Balance />} />
-            <Route path="/adverts" element={<Adverts />} />
-            <Route path="/my-deals" element={<MyDeals />} />
-            <Route path="/ad-deals" element={<AdDeals />} />
-            <Route path="/transactions" element={<Transactions />} />
-            <Route path="/escrow" element={<Escrow />} />
-            <Route path="/orders/:id" element={<OrderItemRoute />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/components/MainLayout.tsx
+++ b/src/components/MainLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router-dom';
+import { Header } from './Header';
+
+export const MainLayout = () => (
+  <>
+    <Header />
+    <Outlet />
+  </>
+);
+
+export default MainLayout;

--- a/src/components/ProfileDrawer.tsx
+++ b/src/components/ProfileDrawer.tsx
@@ -144,7 +144,6 @@ export const ProfileDrawer = ({ triggerClassName }: Props) => {
   useEffect(() => { twoFactorEnabled ? saveTwoFactorEnabled(true) : clearTwoFactorEnabled(); }, [twoFactorEnabled]);
   useEffect(() => { if (userInfo) setTwoFactorEnabled(userInfo.twofaEnabled); }, [userInfo]);
   useEffect(() => { if (!show2faDialog) { setTwoFactorSecret(null); setOtpAuthUrl(null); setPasswordCheck(''); } }, [show2faDialog]);
-  useEffect(() => { refresh().catch(console.error); }, []);
 
   useEffect(() => {
     if (showPaymentMethodsDialog) {

--- a/src/pages/AdDeals.tsx
+++ b/src/pages/AdDeals.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
 import { getClientOrders, type OrderFull } from '@/api/orders';
 import { OrderCard } from '@/components/OrderCard';
@@ -28,7 +27,6 @@ const AdDeals = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-      <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.adDeals')}</h1>
         <ul className="space-y-4">

--- a/src/pages/Adverts.tsx
+++ b/src/pages/Adverts.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
 import {
   getClientOffers,
@@ -48,7 +47,6 @@ const Adverts = () => {
 
   return (
       <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-      <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.adverts')}</h1>
         <ul className="space-y-4">

--- a/src/pages/Balance.tsx
+++ b/src/pages/Balance.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
 import { getClientAssets, createWallet, ClientAsset } from '@/api';
 import { Copy, Check, Wallet } from 'lucide-react';
@@ -156,7 +155,6 @@ const Balance = () => {
 
   return (
       <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-        <Header />
         <div className="container mx-auto px-4 pt-24 pb-8">
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">{t('header.balance')}</h1>
           <p className="mt-1 mb-5 text-sm text-white/60">{t('balance.subtitle', { defaultValue: 'Your assets and deposit addresses' })}</p>

--- a/src/pages/Escrow.tsx
+++ b/src/pages/Escrow.tsx
@@ -1,11 +1,9 @@
-import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
 
 const Escrow = () => {
   const { t } = useTranslation();
   return (
     <div className="min-h-screen bg-gray-900 text-white">
-      <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.escrow')}</h1>
       </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,6 +1,5 @@
 
 import { useState } from 'react';
-import { Header } from '@/components/Header';
 import { OfferList } from '@/components/OfferList';
 
 import { FilterPanel } from '@/components/FilterPanel';
@@ -18,8 +17,6 @@ const Index = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-      <Header />
-
       <div className="container mx-auto px-2 pt-4 sm:pt-6">
         {/* Trading
         <TradingStats />

--- a/src/pages/MyDeals.tsx
+++ b/src/pages/MyDeals.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import { Header } from '@/components/Header';
 import { useTranslation } from 'react-i18next';
 import { getClientOrders, type OrderFull } from '@/api/orders';
 import { OrderCard } from '@/components/OrderCard';
@@ -28,7 +27,6 @@ const MyDeals = () => {
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-      <Header />
       <div className="container mx-auto px-4 pt-24 pb-8">
         <h1 className="text-2xl font-bold mb-4">{t('header.myDeals')}</h1>
         <ul className="space-y-4">

--- a/src/pages/OrderItem.tsx
+++ b/src/pages/OrderItem.tsx
@@ -16,7 +16,6 @@ import { useTranslation } from 'react-i18next';
 import { getOrder, type OrderFull } from '@/api/orders';
 import { ChatPanel } from '@/components/chat/ChatPanel';
 import { cn } from '@/lib/utils';
-import { Header } from '@/components/Header';
 
 // ===== shared countdown (как в OrderCard) =====
 function useCountdown(expiresAt?: string | null) {
@@ -121,8 +120,6 @@ export default function OrderItem({
     return (
         <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
             {/* Глобальная навигация как в списке */}
-            <Header />
-
             <div className="container mx-auto px-4 pt-24 pb-8">
                 {/* TOP BAR: Back + breadcrumbs + status/escrow/timer */}
                 <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useState } from 'react';
-import { Header } from '@/components/Header';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { useTranslation } from 'react-i18next';
 import {
@@ -211,7 +210,6 @@ const Transactions = () => {
 
   return (
       <div className="min-h-screen bg-gradient-to-b from-gray-950 via-gray-900 to-gray-950 text-white">
-        <Header />
         <div className="container mx-auto px-4 pt-24 pb-10">
           <div className="mb-6 flex items-end justify-between gap-4">
             <div>


### PR DESCRIPTION
## Summary
- перенёс Header в общий MainLayout, чтобы исключить размонтирование при переходах
- удалил автоматический вызов refresh в ProfileDrawer
- очистил страницы от локального импорта Header

## Testing
- `npm test`
- `npm run lint` *(ошибки в существующем коде)*

------
https://chatgpt.com/codex/tasks/task_e_68aedfd5b67883329f17b7985a46d00e