### PR TITLE
fix: отправка сообщений в чате ордера

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -86,3 +86,24 @@ export function getClientOrders(role: 'author' | 'offerOwner' = 'author') {
 export function getOrder(id: string) {
   return apiRequest<OrderFull>(`/orders/${id}`);
 }
+
+export interface OrderMessage {
+  id: string;
+  chatID: string;
+  clientID: string;
+  content: string;
+  createdAt: string;
+  updatedAt?: string;
+  readAt?: string;
+  fileURL?: string;
+  fileType?: string;
+  fileSize?: number;
+  type?: string;
+}
+
+export function createOrderMessage(orderId: string, content: string) {
+  return apiRequest<OrderMessage>(`/orders/${orderId}/messages`, {
+    method: 'POST',
+    body: JSON.stringify({ content }),
+  });
+}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -25,10 +25,10 @@ export function ChatPanel({
         el.scrollTop = el.scrollHeight;
     }, [messages.length]);
 
-    const onSend = () => {
+    const onSend = async () => {
         const text = draft.trim();
         if (!text) return;
-        const ok = sendMessage(text);
+        const ok = await sendMessage(text);
         if (ok) setDraft('');
     };
 

--- a/src/hooks/useOrderChat.ts
+++ b/src/hooks/useOrderChat.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { createOrderMessage } from '@/api/orders';
 
 export type ChatMessage = {
     id: string;
@@ -37,11 +38,14 @@ export function useOrderChat(
     const [isConnected, setConnected] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
 
-    const sendMessage = useCallback((body: string) => {
-        if (!wsRef.current || wsRef.current.readyState !== WebSocket.OPEN) return false;
-        wsRef.current.send(JSON.stringify({ type: 'NEW_MESSAGE', body }));
-        return true;
-    }, []);
+    const sendMessage = useCallback(async (body: string) => {
+        try {
+            await createOrderMessage(orderId, body);
+            return true;
+        } catch {
+            return false;
+        }
+    }, [orderId]);
 
     useEffect(() => {
         if (!token || !orderId) return;


### PR DESCRIPTION
## Summary
- отправка сообщений ордера через REST API
- ожидание результата отправки в панели чата

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aee05050c0833292a4736fee4f07ca