### PR TITLE
feat: поддержка файлов и смайлов в чате

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -18,7 +18,10 @@ export async function apiRequest<T>(
 ): Promise<T> {
   const tokens = loadTokens();
   const headers = new Headers(options.headers);
-  headers.set('Content-Type', 'application/json');
+  // если отправляем FormData, пусть браузер сам поставит заголовок
+  if (!(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
   if (tokens?.access) {
     headers.set('Authorization', `Bearer ${tokens.access}`);
   }

--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -101,7 +101,18 @@ export interface OrderMessage {
   type?: string;
 }
 
-export function createOrderMessage(orderId: string, content: string) {
+export function createOrderMessage(orderId: string, content: string, file?: File) {
+  if (file) {
+    const formData = new FormData();
+    if (content) {
+      formData.append('content', content);
+    }
+    formData.append('file', file);
+    return apiRequest<OrderMessage>(`/orders/${orderId}/messages`, {
+      method: 'POST',
+      body: formData,
+    });
+  }
   return apiRequest<OrderMessage>(`/orders/${orderId}/messages`, {
     method: 'POST',
     body: JSON.stringify({ content }),

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import { Send } from 'lucide-react';
+import { Send, Paperclip, Smile } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { ChatMessage, useOrderChat } from '@/hooks/useOrderChat';
 import { MessageBubble } from './MessageBubble';
@@ -16,7 +16,10 @@ export function ChatPanel({
     const { t } = useTranslation();
     const { messages, isConnected, sendMessage } = useOrderChat(orderId, token);
     const [draft, setDraft] = useState('');
+    const [file, setFile] = useState<File | null>(null);
+    const [showEmoji, setShowEmoji] = useState(false);
     const listRef = useRef<HTMLDivElement | null>(null);
+    const fileInputRef = useRef<HTMLInputElement | null>(null);
 
     // автоскролл вниз при новых сообщениях
     useEffect(() => {
@@ -27,9 +30,23 @@ export function ChatPanel({
 
     const onSend = async () => {
         const text = draft.trim();
-        if (!text) return;
-        const ok = await sendMessage(text);
-        if (ok) setDraft('');
+        if (!text && !file) return;
+        const ok = await sendMessage(text, file ?? undefined);
+        if (ok) {
+            setDraft('');
+            setFile(null);
+            if (fileInputRef.current) fileInputRef.current.value = '';
+        }
+    };
+
+    const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const f = e.target.files?.[0];
+        if (f) setFile(f);
+    };
+
+    const addEmoji = (emoji: string) => {
+        setDraft((prev) => prev + emoji);
+        setShowEmoji(false);
     };
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -66,28 +83,76 @@ export function ChatPanel({
                         senderName={m.senderName}
                         isMe={m.senderName === currentUserName}
                         createdAt={m.createdAt}
+                        fileURL={m.fileURL}
+                        fileType={m.fileType}
                     />
                 ))}
             </div>
 
             <div className="p-2 border-t border-white/10">
                 <div className="flex items-end gap-2">
-          <textarea
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              onKeyDown={onKeyDown}
-              rows={1}
-              placeholder={t('orderChat.placeholder', 'Write a message…') as string}
-              className="flex-1 resize-y min-h-[42px] max-h-[140px] rounded-xl bg-white/5 ring-1 ring-white/10 px-3 py-2 text-sm outline-none focus:ring-white/20"
-          />
-                    <button
-                        type="button"
-                        onClick={onSend}
-                        className="inline-flex items-center justify-center rounded-xl px-3 h-[42px] ring-1 ring-white/10 bg-white/5 hover:bg-white/10 transition"
-                        title={t('orderChat.send', 'Send') as string}
-                    >
-                        <Send className="w-4 h-4" />
-                    </button>
+                    <textarea
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onKeyDown={onKeyDown}
+                        rows={1}
+                        placeholder={t('orderChat.placeholder', 'Write a message…') as string}
+                        className="flex-1 resize-y min-h-[42px] max-h-[140px] rounded-xl bg-white/5 ring-1 ring-white/10 px-3 py-2 text-sm outline-none focus:ring-white/20"
+                    />
+                    {file && (
+                        <div className="text-xs text-white/70 max-w-[120px] truncate">
+                            {file.name}
+                        </div>
+                    )}
+                    <div className="flex items-center gap-1">
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/jpeg,image/png,application/pdf"
+                            className="hidden"
+                            onChange={onFileChange}
+                        />
+                        <button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            className="inline-flex items-center justify-center rounded-xl px-2 h-[42px] ring-1 ring-white/10 bg-white/5 hover:bg-white/10 transition"
+                            title={t('orderChat.attach', 'Attach file') as string}
+                        >
+                            <Paperclip className="w-4 h-4" />
+                        </button>
+                        <div className="relative">
+                            <button
+                                type="button"
+                                onClick={() => setShowEmoji((v) => !v)}
+                                className="inline-flex items-center justify-center rounded-xl px-2 h-[42px] ring-1 ring-white/10 bg-white/5 hover:bg-white/10 transition"
+                                title={t('orderChat.emoji', 'Emoji') as string}
+                            >
+                                <Smile className="w-4 h-4" />
+                            </button>
+                            {showEmoji && (
+                                <div className="absolute bottom-12 right-0 bg-gray-800 rounded-xl p-2 ring-1 ring-white/10 flex gap-1 flex-wrap w-40">
+                                    {['😀','😂','😍','👍','😢','🎉'].map((em) => (
+                                        <button
+                                            key={em}
+                                            type="button"
+                                            className="text-lg hover:scale-110 transition"
+                                            onClick={() => addEmoji(em)}
+                                        >
+                                            {em}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onSend}
+                            className="inline-flex items-center justify-center rounded-xl px-3 h-[42px] ring-1 ring-white/10 bg-white/5 hover:bg-white/10 transition"
+                            title={t('orderChat.send', 'Send') as string}
+                        >
+                            <Send className="w-4 h-4" />
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -5,11 +5,15 @@ export function MessageBubble({
                                   senderName,
                                   isMe,
                                   createdAt,
+                                  fileURL,
+                                  fileType,
                               }: {
     body: string;
     senderName?: string;
     isMe: boolean;
     createdAt: string;
+    fileURL?: string;
+    fileType?: string;
 }) {
     return (
         <div className={cn('flex w-full', isMe ? 'justify-end' : 'justify-start')}>
@@ -25,6 +29,23 @@ export function MessageBubble({
                     <div className="text-[11px] mb-0.5 opacity-70">{senderName}</div>
                 )}
                 <div className="whitespace-pre-wrap break-words">{body}</div>
+                {fileURL && fileType?.startsWith('image/') && (
+                    <img
+                        src={fileURL}
+                        alt="attachment"
+                        className="mt-2 max-w-full rounded"
+                    />
+                )}
+                {fileURL && !fileType?.startsWith('image/') && (
+                    <a
+                        href={fileURL}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 text-xs underline break-all inline-block"
+                    >
+                        {fileURL}
+                    </a>
+                )}
                 <div className="mt-1 text-[10px] opacity-60">
                     {new Date(createdAt).toLocaleString()}
                 </div>

--- a/src/hooks/useOrderChat.ts
+++ b/src/hooks/useOrderChat.ts
@@ -8,6 +8,9 @@ export type ChatMessage = {
     senderName?: string;
     body: string;
     createdAt: string;     // ISO
+    fileURL?: string;
+    fileType?: string;
+    fileSize?: number;
 };
 
 type WsCompat = typeof WebSocket & {
@@ -38,9 +41,9 @@ export function useOrderChat(
     const [isConnected, setConnected] = useState(false);
     const wsRef = useRef<WebSocket | null>(null);
 
-    const sendMessage = useCallback(async (body: string) => {
+    const sendMessage = useCallback(async (body: string, file?: File) => {
         try {
-            await createOrderMessage(orderId, body);
+            await createOrderMessage(orderId, body, file);
             return true;
         } catch {
             return false;


### PR DESCRIPTION
## Summary
- добавлена отправка файлов и изображений в чат ордера
- добавлен выбор смайлов и отображение вложений в сообщениях

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee50b50b483329ae3eda5a4719151