### PR TITLE
Добавлены обновления чата и отметка прочитанных сообщений

### DIFF
--- a/src/api/orders.ts
+++ b/src/api/orders.ts
@@ -118,3 +118,9 @@ export function createOrderMessage(orderId: string, content: string, file?: File
     body: JSON.stringify({ content }),
   });
 }
+
+export function markOrderMessageRead(orderId: string, msgId: string) {
+  return apiRequest<OrderMessage>(`/orders/${orderId}/messages/${msgId}/read`, {
+    method: 'PATCH',
+  });
+}

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -65,7 +65,7 @@ export function ChatPanel({
     currentUserName: string
 }) {
     const { t } = useTranslation()
-    const { messages, isConnected, sendMessage } = useOrderChat(orderId, token)
+    const { messages, isConnected, sendMessage, markRead } = useOrderChat(orderId, token)
 
     const [draft, setDraft] = useState('')
     const [file, setFile] = useState<File | null>(null)
@@ -109,6 +109,19 @@ export function ChatPanel({
         el.addEventListener('scroll', handler, { passive: true })
         return () => el.removeEventListener('scroll', handler)
     }, [])
+
+    // mark messages as read when user is at bottom
+    const readSet = useRef<Set<string>>(new Set())
+    useEffect(() => {
+        if (!stickToBottom) return
+        messages.forEach((m) => {
+            if (m.senderName === currentUserName) return
+            if (m.readAt) return
+            if (readSet.current.has(m.id)) return
+            readSet.current.add(m.id)
+            markRead(m.id)
+        })
+    }, [messages, stickToBottom, currentUserName, markRead])
 
     const onSend = async () => {
         const text = draft.trim()
@@ -220,6 +233,7 @@ export function ChatPanel({
                         createdAt={m.createdAt}
                         fileURL={m.fileURL}
                         fileType={m.fileType}
+                        readAt={m.readAt}
                         // allow images to open in a lightbox
                         onImageClick={(src: string) => setLightboxSrc(src)}
                     />

--- a/src/components/chat/MessageBubble.tsx
+++ b/src/components/chat/MessageBubble.tsx
@@ -5,6 +5,7 @@ import {
     Image as ImageIcon,
     Download,
     ExternalLink,
+    Check,
 } from 'lucide-react'
 import { useMemo } from 'react'
 
@@ -17,6 +18,7 @@ export type MessageBubbleProps = {
     fileType?: string
     /** Optional: when provided, images open in a lightbox */
     onImageClick?: (src: string) => void
+    readAt?: string
 }
 
 const IMAGE_MIMES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif']
@@ -81,6 +83,7 @@ export function MessageBubble({
                                   fileURL,
                                   fileType,
                                   onImageClick,
+                                  readAt,
                               }: MessageBubbleProps) {
     const filename = useMemo(() => extractFilename(fileURL), [fileURL])
     const kind = useMemo(() => getFileKind(fileType, filename), [fileType, filename])
@@ -152,8 +155,9 @@ export function MessageBubble({
                     </div>
                 )}
 
-                <div className="mt-1 text-[10px] opacity-60" title={created.toLocaleString()}>
+                <div className="mt-1 flex items-center justify-end gap-1 text-[10px] opacity-60" title={created.toLocaleString()}>
                     {created.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                    {isMe && readAt && <Check className="h-3 w-3" />}
                 </div>
             </div>
         </div>

--- a/src/hooks/useOrderChat.ts
+++ b/src/hooks/useOrderChat.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { createOrderMessage } from '@/api/orders';
+import { createOrderMessage, markOrderMessageRead } from '@/api/orders';
 
 export type ChatMessage = {
     id: string;
@@ -11,6 +11,7 @@ export type ChatMessage = {
     fileURL?: string;
     fileType?: string;
     fileSize?: number;
+    readAt?: string;
 };
 
 type WsCompat = typeof WebSocket & {
@@ -44,6 +45,18 @@ export function useOrderChat(
     const sendMessage = useCallback(async (body: string, file?: File) => {
         try {
             await createOrderMessage(orderId, body, file);
+            return true;
+        } catch {
+            return false;
+        }
+    }, [orderId]);
+
+    const markRead = useCallback(async (msgId: string) => {
+        try {
+            const updated = await markOrderMessageRead(orderId, msgId);
+            setMessages((prev) =>
+                prev.map((m) => (m.id === msgId ? { ...m, readAt: updated.readAt } : m))
+            );
             return true;
         } catch {
             return false;
@@ -113,5 +126,5 @@ export function useOrderChat(
         };
     }, [orderId, token, onConnected, onDisconnected, onError, onHistory]);
 
-    return { messages, isConnected, sendMessage };
+    return { messages, isConnected, sendMessage, markRead };
 }


### PR DESCRIPTION
## Summary
- Поддержка read receipts в чате заказа
- Отправка PATCH на `/orders/{id}/messages/{msgId}/read`
- Иконка прочитанного сообщения в `MessageBubble`

## Testing
- `npm test`
- `npm run lint` *(ошибки)*

------
https://chatgpt.com/codex/tasks/task_e_68aefa698aa08332a2124056bdec1bb0